### PR TITLE
refactor(ui): unify ViewModel state with combine; remove collect*State across screens

### DIFF
--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/domain/manager/ClipboardMonitorManager.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/domain/manager/ClipboardMonitorManager.kt
@@ -53,7 +53,7 @@ import io.github.kdroidfilter.ytdlpgui.core.config.SettingsKeys
  * @param supportedSitesRepository Repository containing information about recognized or supported sites.
  */
 class ClipboardMonitorManager(
-    private val getNavController: () -> NavHostController,
+    private val navController: () -> NavHostController,
     private val settings: Settings,
     private val trayAppState: TrayAppState,
     private val supportedSitesRepository: SupportedSitesRepository,
@@ -127,10 +127,10 @@ class ClipboardMonitorManager(
         val ignoreBtn = getString(Res.string.clipboard_ignore)
 
         fun action() {
-            scope.launch {
+            scope.launch(Dispatchers.Main) {
                 trayAppState.setDismissMode(TrayWindowDismissMode.MANUAL)
                 runCatching { trayAppState.show() }
-                getNavController().navigate(Destination.Download.Single(url))
+                navController().navigate(Destination.Download.Single(url))
                 trayAppState.setDismissMode(TrayWindowDismissMode.AUTO)
             }
         }

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/bulk/BulkDownloadScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/bulk/BulkDownloadScreen.kt
@@ -22,11 +22,12 @@ import io.github.kdroidfilter.ytdlpgui.core.platform.browser.openUrlInBrowser
 import org.jetbrains.compose.resources.stringResource
 import ytdlpgui.composeapp.generated.resources.*
 import org.koin.compose.viewmodel.koinViewModel
+import androidx.compose.runtime.collectAsState
 
 @Composable
 fun BulkDownloadScreen() {
     val viewModel = koinViewModel<BulkDownloadViewModel>()
-    val state = collectBulkDownloadState(viewModel)
+    val state = viewModel.state.collectAsState().value
     BulkDownloadView(
         state = state,
         onEvent = viewModel::onEvents,

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/bulk/BulkDownloadState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/bulk/BulkDownloadState.kt
@@ -1,14 +1,5 @@
 package io.github.kdroidfilter.ytdlpgui.features.download.bulk
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-
 data class BulkDownloadState(
     val isLoading: Boolean = false,
 )
-
-@Composable
-fun collectBulkDownloadState(viewModel: BulkDownloadViewModel): BulkDownloadState =
-    BulkDownloadState(
-        isLoading = viewModel.isLoading.collectAsState().value,
-    )

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/bulk/BulkDownloadViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/bulk/BulkDownloadViewModel.kt
@@ -3,12 +3,25 @@ package io.github.kdroidfilter.ytdlpgui.features.download.bulk
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import androidx.lifecycle.viewModelScope
 
 class BulkDownloadViewModel(navController: NavHostController) : ViewModel() {
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading = _isLoading.asStateFlow()
+
+    // Single UI state for the screen
+    val state = isLoading
+        .map { loading -> BulkDownloadState(isLoading = loading) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = BulkDownloadState()
+        )
 
     fun onEvents(event: BulkDownloadEvents) {
         when (event) {

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadScreen.kt
@@ -56,6 +56,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import ytdlpgui.composeapp.generated.resources.*
 import org.koin.compose.viewmodel.koinViewModel
+import androidx.compose.runtime.collectAsState
 import java.time.Instant
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -64,7 +65,7 @@ import kotlin.math.roundToInt
 @Composable
 fun DownloaderScreen() {
     val viewModel = koinViewModel<DownloadViewModel>()
-    val state = collectDownloadState(viewModel)
+    val state = viewModel.state.collectAsState().value
     DownloadView(
         state = state,
         onEvent = viewModel::onEvents,

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadState.kt
@@ -1,7 +1,4 @@
 package io.github.kdroidfilter.ytdlpgui.features.download.manager
-
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import io.github.kdroidfilter.ytdlp.YtDlpWrapper
 import io.github.kdroidfilter.ytdlp.model.ResolutionAvailability
 import io.github.kdroidfilter.ytdlp.model.VideoInfo
@@ -214,13 +211,3 @@ data class DownloadState(
         )
     }
 }
-
-@Composable
-fun collectDownloadState(viewModel: DownloadViewModel): DownloadState =
-    DownloadState(
-        isLoading = viewModel.isLoading.collectAsState().value,
-        items = viewModel.items.collectAsState().value,
-        history = viewModel.history.collectAsState().value,
-        directoryAvailability = viewModel.directoryAvailability.collectAsState(initial = emptyMap()).value,
-        errorDialogItem = viewModel.errorDialogItem.collectAsState().value,
-    )

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadScreen.kt
@@ -52,6 +52,7 @@ import io.github.kdroidfilter.ytdlp.model.VideoInfo
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
+import androidx.compose.runtime.collectAsState
 import ytdlpgui.composeapp.generated.resources.*
 import java.time.Duration
 import java.util.*
@@ -59,7 +60,7 @@ import java.util.*
 @Composable
 fun SingleDownloadScreen() {
     val viewModel = koinViewModel<SingleDownloadViewModel>()
-    val state = collectSingleDownloadState(viewModel)
+    val state = viewModel.state.collectAsState().value
     SingleDownloadView(
         state = state,
         onEvent = viewModel::onEvents,

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadState.kt
@@ -1,7 +1,5 @@
 package io.github.kdroidfilter.ytdlpgui.features.download.single
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import io.github.kdroidfilter.ytdlp.YtDlpWrapper
 import io.github.kdroidfilter.ytdlp.model.ResolutionAvailability
 import io.github.kdroidfilter.ytdlp.model.SubtitleInfo
@@ -119,15 +117,3 @@ data class SingleDownloadState(
         )
     }
 }
-
-@Composable
-fun collectSingleDownloadState(viewModel: SingleDownloadViewModel): SingleDownloadState =
-    SingleDownloadState(
-        isLoading = viewModel.isLoading.collectAsState().value,
-        errorMessage = viewModel.errorMessage.collectAsState().value,
-        videoInfo = viewModel.videoInfo.collectAsState().value,
-        availablePresets = viewModel.availablePresets.collectAsState().value,
-        selectedPreset = viewModel.selectedPreset.collectAsState().value,
-        availableSubtitles = viewModel.availableSubtitles.collectAsState().value,
-        selectedSubtitles = viewModel.selectedSubtitles.collectAsState().value,
-    )

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/home/HomeScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/home/HomeScreen.kt
@@ -2,6 +2,7 @@ package io.github.kdroidfilter.ytdlpgui.features.home
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -23,7 +24,7 @@ import ytdlpgui.composeapp.generated.resources.*
 @Composable
 fun HomeScreen() {
     val viewModel = koinInject<HomeViewModel>()
-    val state = collectHomeState(viewModel)
+    val state = viewModel.state.collectAsState().value
     HomeView(
         state = state,
         onEvent = viewModel::onEvents,

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/home/HomeState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/home/HomeState.kt
@@ -1,8 +1,5 @@
 package io.github.kdroidfilter.ytdlpgui.features.home
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-
 data class HomeState(
     val link: String = "",
     val isLoading: Boolean = false,
@@ -14,11 +11,3 @@ data class HomeState(
         val errorState = HomeState(errorMessage = "Something went wrong")
     }
 }
-
-@Composable
-fun collectHomeState(viewModel: HomeViewModel) : HomeState =
-    HomeState(
-        link = viewModel.textFieldContent.collectAsState().value,
-        isLoading = viewModel.isLoading.collectAsState().value,
-        errorMessage = viewModel.errorMessage.collectAsState().value,
-    )

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/init/InitScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/init/InitScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -43,7 +44,7 @@ import ytdlpgui.composeapp.generated.resources.updating_ytdlp
 @Composable
 fun InitScreen() {
     val viewModel = koinInject<InitViewModel>()
-    val state = collectInitState(viewModel)
+    val state = viewModel.state.collectAsState().value
     InitView(
         state = state,
         onIgnoreUpdate = { viewModel.ignoreUpdate() }

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/init/InitState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/init/InitState.kt
@@ -1,8 +1,5 @@
 package io.github.kdroidfilter.ytdlpgui.features.init
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-
 data class InitState(
     val checkingYtDlp: Boolean = false,
     val checkingFFmpeg: Boolean = false,
@@ -68,9 +65,4 @@ data class InitState(
             downloadFfmpegProgress = 60.0f
         )
     }
-}
-
-@Composable
-fun collectInitState(viewModel: InitViewModel) : InitState {
-    return viewModel.state.collectAsState().value
 }

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/autostart/AutostartScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/autostart/AutostartScreen.kt
@@ -41,7 +41,9 @@ import ytdlpgui.composeapp.generated.resources.settings_auto_launch_title
 fun AutostartScreen(
     viewModel: OnboardingViewModel = koinViewModel(),
 ) {
-    val state = collectAutostartState(viewModel)
+    val state = AutostartState(
+        autoLaunchEnabled = viewModel.autoLaunchEnabled.collectAsState().value
+    )
     val currentStep by viewModel.currentStep.collectAsState()
     val initState by viewModel.initState.collectAsState()
     val dependencyInfoBarDismissed by viewModel.dependencyInfoBarDismissed.collectAsState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/autostart/AutostartState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/autostart/AutostartState.kt
@@ -1,9 +1,5 @@
 package io.github.kdroidfilter.ytdlpgui.features.onboarding.autostart
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import io.github.kdroidfilter.ytdlpgui.features.onboarding.OnboardingViewModel
-
 data class AutostartState(
     val autoLaunchEnabled: Boolean = false,
 ) {
@@ -12,8 +8,3 @@ data class AutostartState(
         val disabledState = AutostartState(autoLaunchEnabled = false)
     }
 }
-
-@Composable
-fun collectAutostartState(viewModel: OnboardingViewModel): AutostartState = AutostartState(
-    autoLaunchEnabled = viewModel.autoLaunchEnabled.collectAsState().value
-)

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/clipboard/ClipboardScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/clipboard/ClipboardScreen.kt
@@ -29,7 +29,9 @@ import ytdlpgui.composeapp.generated.resources.*
 fun ClipboardScreen(
     viewModel: OnboardingViewModel = koinViewModel(),
 ) {
-    val state = collectClipboardState(viewModel)
+    val state = ClipboardState(
+        clipboardMonitoringEnabled = viewModel.clipboardMonitoringEnabled.collectAsState().value
+    )
     val currentStep by viewModel.currentStep.collectAsState()
     val initState by viewModel.initState.collectAsState()
     val dependencyInfoBarDismissed by viewModel.dependencyInfoBarDismissed.collectAsState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/clipboard/ClipboardState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/clipboard/ClipboardState.kt
@@ -1,9 +1,5 @@
 package io.github.kdroidfilter.ytdlpgui.features.onboarding.clipboard
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import io.github.kdroidfilter.ytdlpgui.features.onboarding.OnboardingViewModel
-
 data class ClipboardState(
     val clipboardMonitoringEnabled: Boolean = false
 ) {
@@ -12,8 +8,3 @@ data class ClipboardState(
         val disabledState = ClipboardState(clipboardMonitoringEnabled = false)
     }
 }
-
-@Composable
-fun collectClipboardState(viewModel: OnboardingViewModel): ClipboardState = ClipboardState(
-    clipboardMonitoringEnabled = viewModel.clipboardMonitoringEnabled.collectAsState().value
-)

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/cookies/CookiesScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/cookies/CookiesScreen.kt
@@ -36,7 +36,9 @@ import io.github.kdroidfilter.ytdlpgui.features.init.InitState
 fun CookiesScreen(
     viewModel: OnboardingViewModel = koinViewModel(),
 ) {
-    val state = collectCookiesState(viewModel)
+    val state = CookiesState(
+        cookiesFromBrowser = viewModel.cookiesFromBrowser.collectAsState().value
+    )
     val currentStep by viewModel.currentStep.collectAsState()
     val initState by viewModel.initState.collectAsState()
     val dependencyInfoBarDismissed by viewModel.dependencyInfoBarDismissed.collectAsState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/cookies/CookiesState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/cookies/CookiesState.kt
@@ -1,9 +1,5 @@
 package io.github.kdroidfilter.ytdlpgui.features.onboarding.cookies
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import io.github.kdroidfilter.ytdlpgui.features.onboarding.OnboardingViewModel
-
 data class CookiesState(
     val cookiesFromBrowser: String = ""
 ) {
@@ -13,9 +9,3 @@ data class CookiesState(
         val firefoxState = CookiesState(cookiesFromBrowser = "firefox")
     }
 }
-
-@Composable
-fun collectCookiesState(viewModel: OnboardingViewModel): CookiesState =
-    CookiesState(
-        cookiesFromBrowser = viewModel.cookiesFromBrowser.collectAsState().value
-    )

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/downloaddir/DownloadDirScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/downloaddir/DownloadDirScreen.kt
@@ -43,7 +43,9 @@ import io.github.kdroidfilter.ytdlpgui.features.init.InitState
 fun DownloadDirScreen(
     viewModel: OnboardingViewModel = koinViewModel(),
 ) {
-    val state = collectDownloadDirState(viewModel)
+    val state = DownloadDirState(
+        downloadDirPath = viewModel.downloadDirPath.collectAsState().value
+    )
     val currentStep by viewModel.currentStep.collectAsState()
     val initState by viewModel.initState.collectAsState()
     val dependencyInfoBarDismissed by viewModel.dependencyInfoBarDismissed.collectAsState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/downloaddir/DownloadDirState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/downloaddir/DownloadDirState.kt
@@ -1,9 +1,5 @@
 package io.github.kdroidfilter.ytdlpgui.features.onboarding.downloaddir
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import io.github.kdroidfilter.ytdlpgui.features.onboarding.OnboardingViewModel
-
 data class DownloadDirState(
     val downloadDirPath: String = ""
 ) {
@@ -14,9 +10,3 @@ data class DownloadDirState(
         )
     }
 }
-
-@Composable
-fun collectDownloadDirState(viewModel: OnboardingViewModel): DownloadDirState =
-    DownloadDirState(
-        downloadDirPath = viewModel.downloadDirPath.collectAsState().value
-    )

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/nocheckcert/NoCheckCertScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/nocheckcert/NoCheckCertScreen.kt
@@ -43,7 +43,9 @@ import io.github.kdroidfilter.ytdlpgui.features.init.InitState
 fun NoCheckCertScreen(
     viewModel: OnboardingViewModel = koinViewModel(),
 ) {
-    val state = collectNoCheckCertState(viewModel)
+    val state = NoCheckCertState(
+        noCheckCertificate = viewModel.noCheckCertificate.collectAsState().value
+    )
     val currentStep by viewModel.currentStep.collectAsState()
     val initState by viewModel.initState.collectAsState()
     val dependencyInfoBarDismissed by viewModel.dependencyInfoBarDismissed.collectAsState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/nocheckcert/NoCheckCertState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/nocheckcert/NoCheckCertState.kt
@@ -1,9 +1,5 @@
 package io.github.kdroidfilter.ytdlpgui.features.onboarding.nocheckcert
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import io.github.kdroidfilter.ytdlpgui.features.onboarding.OnboardingViewModel
-
 data class NoCheckCertState(
     val noCheckCertificate: Boolean = false
 ) {
@@ -12,8 +8,3 @@ data class NoCheckCertState(
         val disabledState = NoCheckCertState(noCheckCertificate = false)
     }
 }
-
-@Composable
-fun collectNoCheckCertState(viewModel: OnboardingViewModel): NoCheckCertState = NoCheckCertState(
-    noCheckCertificate = viewModel.noCheckCertificate.collectAsState().value
-)

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsScreen.kt
@@ -42,11 +42,12 @@ import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import ytdlpgui.composeapp.generated.resources.Res
 import ytdlpgui.composeapp.generated.resources.*
+import androidx.compose.runtime.collectAsState
 
 @Composable
 fun SettingsScreen() {
     val viewModel = koinViewModel<SettingsViewModel>()
-    val state = collectSettingsState(viewModel)
+    val state = viewModel.state.collectAsState().value
     SettingsView(
         state = state,
         onEvent = viewModel::onEvents,

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsState.kt
@@ -1,8 +1,5 @@
 package io.github.kdroidfilter.ytdlpgui.features.system.settings
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-
 // UI state for the Settings screen
 // - noCheckCertificate: when true, yt-dlp will be called with --no-check-certificates
 // - cookiesFromBrowser: the browser name to use for --cookies-from-browser (e.g., "firefox", "chrome"), empty to disable
@@ -71,18 +68,3 @@ data class SettingsState(
         )
     }
 }
-
-@Composable
-fun collectSettingsState(viewModel: SettingsViewModel): SettingsState =
-    SettingsState(
-        isLoading = viewModel.isLoading.collectAsState().value,
-        noCheckCertificate = viewModel.noCheckCertificate.collectAsState().value,
-        cookiesFromBrowser = viewModel.cookiesFromBrowser.collectAsState().value,
-        includePresetInFilename = viewModel.includePresetInFilename.collectAsState().value,
-        embedThumbnailInMp3 = viewModel.embedThumbnailInMp3.collectAsState().value,
-        parallelDownloads = viewModel.parallelDownloads.collectAsState().value,
-        downloadDirPath = viewModel.downloadDirPath.collectAsState().value,
-        clipboardMonitoringEnabled = viewModel.clipboardMonitoring.collectAsState().value,
-        autoLaunchEnabled = viewModel.autoLaunchEnabled.collectAsState().value,
-        notifyOnComplete = viewModel.notifyOnComplete.collectAsState().value,
-    )

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsViewModel.kt
@@ -15,7 +15,12 @@ import io.github.vinceglb.filekit.dialogs.openDirectoryPicker
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import io.github.kdroidfilter.ytdlpgui.features.system.settings.SettingsState
+import androidx.lifecycle.viewModelScope
 
 class SettingsViewModel(
     private val navController: NavHostController,
@@ -36,6 +41,47 @@ class SettingsViewModel(
     val clipboardMonitoring: StateFlow<Boolean> = settingsRepository.clipboardMonitoringEnabled
     val notifyOnComplete: StateFlow<Boolean> = settingsRepository.notifyOnComplete
     val autoLaunchEnabled: StateFlow<Boolean> = settingsRepository.autoLaunchEnabled
+
+    // Combined UI state for settings
+    val state = combine(
+        isLoading,
+        noCheckCertificate,
+        cookiesFromBrowser,
+        includePresetInFilename,
+        embedThumbnailInMp3,
+        parallelDownloads,
+        downloadDirPath,
+        clipboardMonitoring,
+        autoLaunchEnabled,
+        notifyOnComplete,
+    ) { values: Array<Any?> ->
+        val loading = values[0] as Boolean
+        val noCheck = values[1] as Boolean
+        val cookies = values[2] as String
+        val includePreset = values[3] as Boolean
+        val embedThumb = values[4] as Boolean
+        val parallel = values[5] as Int
+        val downloadDir = values[6] as String
+        val clipboard = values[7] as Boolean
+        val autoLaunch = values[8] as Boolean
+        val notify = values[9] as Boolean
+        SettingsState(
+            isLoading = loading,
+            noCheckCertificate = noCheck,
+            cookiesFromBrowser = cookies,
+            includePresetInFilename = includePreset,
+            embedThumbnailInMp3 = embedThumb,
+            parallelDownloads = parallel,
+            downloadDirPath = downloadDir,
+            clipboardMonitoringEnabled = clipboard,
+            autoLaunchEnabled = autoLaunch,
+            notifyOnComplete = notify,
+        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5_000),
+        initialValue = SettingsState.defaultState,
+    )
 
     init {
         // Query system autostart state at startup asynchronously


### PR DESCRIPTION
- Consolidates multiple flows into a single StateFlow per screen via Flow.combine + stateIn (Home, Single, Bulk, Download Manager, Settings, Init).
- Removes collect*State composables; screens now collect viewModel.state (or build tiny inline state for onboarding steps).
- Uses array-based combine transform for 7–10 flows to match kotlinx-coroutines 1.10.2 overloads.
- Reduces recompositions and simplifies state wiring; no user-visible UI changes expected.