### PR TITLE
ci: add Build and Test workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,28 @@
+name: Build and Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up temurin JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: '8.12'
+
+      - name: Build and run tests
+        run: ./gradlew check
+


### PR DESCRIPTION
Adds GitHub Actions workflow 'Build and Test' that runs './gradlew check' on push and pull_request (Ubuntu).\n\nProtection on 'main' will require this check to pass.