### PR TITLE
feat(logging): centralize -DdebugLogs flag and enable logs in IDE runs

### DIFF
--- a/.run/README.md
+++ b/.run/README.md
@@ -8,11 +8,13 @@ This directory contains pre-configured run configurations for IntelliJ IDEA / An
 - **Purpose**: Normal development mode
 - **Settings**: Preserves all application settings and cache
 - **Use when**: Regular development, testing features with existing data
+- **Logs**: Enabled via `-PdebugLogs=true`
 
 ### 🧹 Run (Clean Install)
 - **Purpose**: Clean installation mode for testing onboarding
 - **Settings**: Clears all settings and cache on startup
 - **Use when**: Testing the onboarding flow from scratch
+- **Logs**: Enabled via `-PcleanInstall=true -PdebugLogs=true`
 
 ## How to Use
 
@@ -23,8 +25,8 @@ This directory contains pre-configured run configurations for IntelliJ IDEA / An
 
 ## Technical Details
 
-- **Normal mode**: Runs with default settings (`cleanInstall=false`)
-- **Clean Install mode**: Runs with `-PcleanInstall=true` gradle property
+- **Normal mode**: Runs with default settings (`cleanInstall=false`) and logs enabled (`-PdebugLogs=true`)
+- **Clean Install mode**: Runs with `-PcleanInstall=true` and logs enabled (`-PdebugLogs=true`)
   - Clears Java temp directory (`/tmp`)
   - Clears all application settings (forces onboarding)
 

--- a/.run/Run (Clean Install).run.xml
+++ b/.run/Run (Clean Install).run.xml
@@ -4,7 +4,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="-PcleanInstall=true" />
+      <option name="scriptParameters" value="-PcleanInstall=true -PdebugLogs=true" />
       <option name="taskDescriptions">
         <list />
       </option>

--- a/.run/Run (Normal).run.xml
+++ b/.run/Run (Normal).run.xml
@@ -4,7 +4,7 @@
       <option name="executionName" />
       <option name="externalProjectPath" value="$PROJECT_DIR$" />
       <option name="externalSystemIdString" value="GRADLE" />
-      <option name="scriptParameters" value="" />
+      <option name="scriptParameters" value="-PdebugLogs=true" />
       <option name="taskDescriptions">
         <list />
       </option>

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -103,8 +103,10 @@ compose.desktop {
         mainClass = "io.github.kdroidfilter.ytdlpgui.MainKt"
 
         val cleanInstall = project.findProperty("cleanInstall")?.toString()?.toBoolean() ?: false
+        val debugLogs = project.findProperty("debugLogs")?.toString()?.toBoolean() ?: false
         jvmArgs += listOf(
-            "-DcleanInstall=$cleanInstall"
+            "-DcleanInstall=$cleanInstall",
+            "-DdebugLogs=$debugLogs"
         )
 
 

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/data/SettingsRepository.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/data/SettingsRepository.kt
@@ -134,7 +134,7 @@ class SettingsRepository(
         val detected = try {
             autoLaunch.isEnabled()
         } catch (e: Exception) {
-            println("Failed to check auto launch state: ${e.message}")
+            io.github.kdroidfilter.logging.errorln { "Failed to check auto launch state: ${e.message}" }
             current
         }
         _autoLaunchEnabled.value = detected

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/main.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/main.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -32,27 +31,24 @@ import com.kdroid.composetray.tray.api.rememberTrayAppState
 import com.kdroid.composetray.utils.SingleInstanceManager
 import com.kdroid.composetray.utils.allowComposeNativeTrayLogging
 import com.kdroid.composetray.utils.isMenuBarInDarkMode
+import com.russhwolf.settings.Settings
 import io.github.composefluent.ExperimentalFluentApi
 import io.github.composefluent.FluentTheme
 import io.github.composefluent.background.Mica
 import io.github.composefluent.darkColors
-import io.github.composefluent.icons.Icons
-import io.github.composefluent.icons.regular.Clipboard
-import io.github.composefluent.icons.regular.Eye
-import io.github.composefluent.icons.regular.EyeOff
-import io.github.composefluent.icons.regular.Info
 import io.github.composefluent.lightColors
 import io.github.kdroidfilter.knotify.builder.AppConfig
 import io.github.kdroidfilter.knotify.builder.NotificationInitializer
+import io.github.kdroidfilter.logging.LoggerConfig
+import io.github.kdroidfilter.logging.errorln
+import io.github.kdroidfilter.logging.infoln
 import io.github.kdroidfilter.platformtools.OperatingSystem
 import io.github.kdroidfilter.platformtools.darkmodedetector.isSystemInDarkMode
 import io.github.kdroidfilter.platformtools.getAppVersion
 import io.github.kdroidfilter.platformtools.getOperatingSystem
-import io.github.kdroidfilter.ytdlpgui.core.domain.manager.DownloadManager
 import io.github.kdroidfilter.ytdlpgui.core.design.icons.AeroDlLogoOnly
 import io.github.kdroidfilter.ytdlpgui.core.design.icons.AeroDlLogoOnlyRtl
-import io.github.kdroidfilter.logging.errorln
-import io.github.kdroidfilter.logging.infoln
+import io.github.kdroidfilter.ytdlpgui.core.domain.manager.DownloadManager
 import io.github.kdroidfilter.ytdlpgui.di.appModule
 import io.github.kdroidfilter.ytdlpgui.features.system.settings.SettingsEvents
 import io.github.kdroidfilter.ytdlpgui.features.system.settings.SettingsViewModel
@@ -63,20 +59,12 @@ import org.koin.compose.KoinApplication
 import org.koin.compose.getKoin
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
-import ytdlpgui.composeapp.generated.resources.Res
-import ytdlpgui.composeapp.generated.resources.app_name
-import ytdlpgui.composeapp.generated.resources.menu_hide_window
-import ytdlpgui.composeapp.generated.resources.menu_show_window
-import ytdlpgui.composeapp.generated.resources.quit
-import ytdlpgui.composeapp.generated.resources.settings_auto_launch_title
-import ytdlpgui.composeapp.generated.resources.settings_clipboard_monitoring_title
-import ytdlpgui.composeapp.generated.resources.app_version_label
+import ytdlpgui.composeapp.generated.resources.*
 import java.io.File
-import com.russhwolf.settings.Settings
 
 @OptIn(ExperimentalTrayAppApi::class, ExperimentalFluentApi::class)
 fun main() = application {
-    allowComposeNativeTrayLogging = true
+    allowComposeNativeTrayLogging = LoggerConfig.enabled
     val cleanInstall = System.getProperty("cleanInstall", "false").toBoolean()
 
     if (cleanInstall) {

--- a/logging/src/jvmMain/kotlin/io/github/kdroidfilter/logging/Logger.kt
+++ b/logging/src/jvmMain/kotlin/io/github/kdroidfilter/logging/Logger.kt
@@ -8,7 +8,7 @@ import java.util.Date
  * Provides level filtering, optional timestamps, and ANSI colors.
  */
 object LoggerConfig {
-    @Volatile var enabled: Boolean = true
+    @Volatile var enabled: Boolean = System.getProperty("debugLogs", "false").toBoolean()
     @Volatile var level: LoggingLevel = LoggingLevel.VERBOSE
     @Volatile var showTimestamp: Boolean = true
     @Volatile var useColors: Boolean = true
@@ -31,6 +31,7 @@ private const val COLOR_ORANGE = "\u001b[38;2;255;165;0m"
 private const val COLOR_RESET = "\u001b[0m"
 
 private fun nowString(): String = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(Date())
+
 
 private fun logAt(minLevel: LoggingLevel, color: String, tag: String, message: () -> String) {
     if (!LoggerConfig.enabled || LoggerConfig.level.priority > minLevel.priority) return

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -24,6 +24,9 @@ kotlin {
 
             // Security - Native trusted roots
             implementation(libs.jvm.native.trusted.roots)
+
+            // Internal logging module for shared logging config
+            implementation(project(":logging"))
         }
     }
 }

--- a/network/src/jvmMain/kotlin/io/github/kdroidfilter/network/CoilConfig.kt
+++ b/network/src/jvmMain/kotlin/io/github/kdroidfilter/network/CoilConfig.kt
@@ -9,6 +9,7 @@ import coil3.memory.MemoryCache
 import okhttp3.OkHttpClient
 import java.io.File
 import okio.Path.Companion.toPath
+import io.github.kdroidfilter.logging.LoggerConfig
 
 /**
  * Provides Coil ImageLoader configuration that uses native OS certificate stores.
@@ -32,7 +33,7 @@ object CoilConfig {
      * @param logger Optional logger for debugging (default: DebugLogger)
      * @return Configured ImageLoader instance
      */
-    fun createImageLoader(logger: Logger? = DebugLogger()): ImageLoader {
+    fun createImageLoader(logger: Logger? = if (LoggerConfig.enabled) DebugLogger() else null): ImageLoader {
         val cacheBase = File(System.getProperty("user.home"), ".aerodl/coil_cache").apply { mkdirs() }
         return ImageLoader.Builder(coil3.PlatformContext.INSTANCE)
             .components {

--- a/network/src/jvmMain/kotlin/io/github/kdroidfilter/network/KtorConfig.kt
+++ b/network/src/jvmMain/kotlin/io/github/kdroidfilter/network/KtorConfig.kt
@@ -6,6 +6,7 @@ import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.plugins.logging.*
 import io.ktor.serialization.kotlinx.json.*
 import kotlinx.serialization.json.Json
+import io.github.kdroidfilter.logging.LoggerConfig
 
 /**
  * Provides a configured Ktor HttpClient that uses native OS certificate stores.
@@ -20,7 +21,7 @@ object KtorConfig {
      * @return Configured HttpClient instance
      */
     fun createHttpClient(
-        logLevel: LogLevel = LogLevel.INFO,
+        logLevel: LogLevel = if (LoggerConfig.enabled) LogLevel.INFO else LogLevel.NONE,
         json: Json = Json {
             ignoreUnknownKeys = true
             isLenient = true


### PR DESCRIPTION
feat: centralize -DdebugLogs flag and enable logs in IDE runs

Summary
- Introduces a single global flag (-DdebugLogs) to control all runtime logs.
- Ensures IntelliJ Run configs enable logs automatically for Normal and Clean Install modes.

User Impact
- Logs appear only when requested via -DdebugLogs=true (or via IntelliJ Run configs included in repo).
- No logs shown by default in packaged/terminal runs.

Changes
- logging: LoggerConfig.enabled reads System.getProperty("debugLogs").
- composeApp: pass -DdebugLogs from Gradle when -PdebugLogs is set; tray logs follow LoggerConfig.enabled.
- network(Ktor): default LogLevel=INFO when LoggerConfig.enabled, otherwise NONE.
- network(Coil): DebugLogger enabled when LoggerConfig.enabled.
- network: depend on :logging for shared config.
- composeApp: replace stray println with errorln in SettingsRepository.
- .run: add -PdebugLogs=true to Run (Normal) and Run (Clean Install).

Testing
- IntelliJ: Use Run (Normal) or Run (Clean Install); logs should be visible.
- CLI: `./gradlew :composeApp:run -PdebugLogs=true` to enable logs; no logs if omitted.

Notes
- Property name can be changed easily (single source of truth).
- No behavior change in production unless -DdebugLogs is explicitly set.
