### PR TITLE
Refactor UI state handling and add Build and Test workflow

### DIFF
--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/ui/Header.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/ui/Header.kt
@@ -41,7 +41,7 @@ fun MainNavigationHeader(
     val currentDestination = backStackEntry?.destination
     // App update badge state (from InitViewModel)
     val initViewModel = koinInject<InitViewModel>()
-    val initState = initViewModel.uiState.collectAsState().value
+    val initState by initViewModel.uiState.collectAsState()
     val showUpdateBadge = initState.updateAvailable && !initState.updateDismissed
 
     val scope = rememberCoroutineScope()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/bulk/BulkDownloadScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/bulk/BulkDownloadScreen.kt
@@ -23,11 +23,12 @@ import org.jetbrains.compose.resources.stringResource
 import ytdlpgui.composeapp.generated.resources.*
 import org.koin.compose.viewmodel.koinViewModel
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 
 @Composable
 fun BulkDownloadScreen() {
     val viewModel = koinViewModel<BulkDownloadViewModel>()
-    val state = viewModel.uiState.collectAsState().value
+    val state by viewModel.uiState.collectAsState()
     BulkDownloadView(
         state = state,
         onEvent = viewModel::handleEvent,

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadScreen.kt
@@ -54,7 +54,7 @@ import kotlin.math.roundToInt
 @Composable
 fun DownloaderScreen() {
     val viewModel = koinViewModel<DownloadViewModel>()
-    val state = viewModel.uiState.collectAsState().value
+    val state by viewModel.uiState.collectAsState()
     DownloadView(
         state = state,
         onEvent = viewModel::handleEvent,

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadScreen.kt
@@ -60,7 +60,7 @@ import java.util.*
 @Composable
 fun SingleDownloadScreen() {
     val viewModel = koinViewModel<SingleDownloadViewModel>()
-    val state = viewModel.uiState.collectAsState().value
+    val state by viewModel.uiState.collectAsState()
     SingleDownloadView(
         state = state,
         onEvent = viewModel::handleEvent,

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/home/HomeScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/home/HomeScreen.kt
@@ -3,6 +3,7 @@ package io.github.kdroidfilter.ytdlpgui.features.home
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
@@ -24,7 +25,7 @@ import ytdlpgui.composeapp.generated.resources.*
 @Composable
 fun HomeScreen() {
     val viewModel = koinInject<HomeViewModel>()
-    val state = viewModel.uiState.collectAsState().value
+    val state by viewModel.uiState.collectAsState()
     HomeView(
         state = state,
         onEvent = viewModel::handleEvent,
@@ -69,7 +70,14 @@ fun HomeView(
                 header = {
                     val (headerText, headerColor) = when {
                         state.isLoading -> stringResource(Res.string.loading) to FluentTheme.colors.text.text.tertiary
-                        state.errorMessage != null -> state.errorMessage to FluentTheme.colors.system.critical
+                        state.errorMessage != null -> {
+                            val msg = when (state.errorMessage) {
+                                HomeError.SingleValidUrl -> stringResource(Res.string.error_single_valid_url)
+                                HomeError.InvalidUrlFormat -> stringResource(Res.string.error_invalid_url_format)
+                                HomeError.UrlRequired -> stringResource(Res.string.error_url_required)
+                            }
+                            msg to FluentTheme.colors.system.critical
+                        }
                         else -> stringResource(Res.string.paste_video_link_header) to FluentTheme.colors.text.text.disabled
                     }
                     Text(

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/home/HomeState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/home/HomeState.kt
@@ -1,13 +1,19 @@
 package io.github.kdroidfilter.ytdlpgui.features.home
 
+enum class HomeError {
+    SingleValidUrl,
+    InvalidUrlFormat,
+    UrlRequired,
+}
+
 data class HomeState(
     val link: String = "",
     val isLoading: Boolean = false,
-    val errorMessage: String? = null,
+    val errorMessage: HomeError? = null,
 ) {
     companion object {
         val loadingState = HomeState(isLoading = true)
         val emptyState = HomeState()
-        val errorState = HomeState(errorMessage = "Something went wrong")
+        val errorState = HomeState(errorMessage = HomeError.InvalidUrlFormat)
     }
 }

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/home/HomeViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/home/HomeViewModel.kt
@@ -7,7 +7,6 @@ import io.github.kdroidfilter.ytdlpgui.core.navigation.Destination
 import io.github.kdroidfilter.ytdlpgui.core.ui.MVIViewModel
 import kotlinx.coroutines.launch
 import java.awt.Toolkit.getDefaultToolkit
-import org.jetbrains.compose.resources.getString
 import ytdlpgui.composeapp.generated.resources.*
 import java.awt.datatransfer.DataFlavor
 import java.net.URI
@@ -60,10 +59,7 @@ class HomeViewModel(
 
         if (matches.size != 1 || matches.first().value != input) {
             // Either multiple URLs or extra text around the URL
-            viewModelScope.launch {
-                val error = getString(Res.string.error_single_valid_url)
-                update { copy(errorMessage = error) }
-            }
+            update { copy(errorMessage = HomeError.SingleValidUrl) }
             return false
         }
 
@@ -75,10 +71,7 @@ class HomeViewModel(
             update { copy(errorMessage = null) }
             true
         } catch (e: Exception) {
-            viewModelScope.launch {
-                val error = getString(Res.string.error_invalid_url_format)
-                update { copy(errorMessage = error) }
-            }
+            update { copy(errorMessage = HomeError.InvalidUrlFormat) }
             false
         }
     }
@@ -87,10 +80,7 @@ class HomeViewModel(
         val current = uiState.value.link
         // If empty, show an explicit error when Next is pressed
         if (current.trim().isEmpty()) {
-            viewModelScope.launch {
-                val error = getString(Res.string.error_url_required)
-                update { copy(errorMessage = error) }
-            }
+            update { copy(errorMessage = HomeError.UrlRequired) }
             return
         }
         val isValid = validateLink(current)

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/init/InitScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/init/InitScreen.kt
@@ -38,7 +38,7 @@ import ytdlpgui.composeapp.generated.resources.updating_ytdlp
 @Composable
 fun InitScreen() {
     val viewModel = koinInject<InitViewModel>()
-    val state = viewModel.uiState.collectAsState().value
+    val state by viewModel.uiState.collectAsState()
     InitView(
         state = state,
     )

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/autostart/AutostartScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/autostart/AutostartScreen.kt
@@ -41,8 +41,9 @@ import ytdlpgui.composeapp.generated.resources.settings_auto_launch_title
 fun AutostartScreen(
     viewModel: OnboardingViewModel = koinViewModel(),
 ) {
+    val autoLaunchEnabled by viewModel.autoLaunchEnabled.collectAsState()
     val state = AutostartState(
-        autoLaunchEnabled = viewModel.autoLaunchEnabled.collectAsState().value
+        autoLaunchEnabled = autoLaunchEnabled
     )
     val currentStep by viewModel.currentStep.collectAsState()
     val initState by viewModel.initState.collectAsState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/clipboard/ClipboardScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/clipboard/ClipboardScreen.kt
@@ -29,8 +29,9 @@ import ytdlpgui.composeapp.generated.resources.*
 fun ClipboardScreen(
     viewModel: OnboardingViewModel = koinViewModel(),
 ) {
+    val clipboardMonitoringEnabled by viewModel.clipboardMonitoringEnabled.collectAsState()
     val state = ClipboardState(
-        clipboardMonitoringEnabled = viewModel.clipboardMonitoringEnabled.collectAsState().value
+        clipboardMonitoringEnabled = clipboardMonitoringEnabled
     )
     val currentStep by viewModel.currentStep.collectAsState()
     val initState by viewModel.initState.collectAsState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/cookies/CookiesScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/cookies/CookiesScreen.kt
@@ -36,8 +36,9 @@ import io.github.kdroidfilter.ytdlpgui.features.init.InitState
 fun CookiesScreen(
     viewModel: OnboardingViewModel = koinViewModel(),
 ) {
+    val cookiesFromBrowser by viewModel.cookiesFromBrowser.collectAsState()
     val state = CookiesState(
-        cookiesFromBrowser = viewModel.cookiesFromBrowser.collectAsState().value
+        cookiesFromBrowser = cookiesFromBrowser
     )
     val currentStep by viewModel.currentStep.collectAsState()
     val initState by viewModel.initState.collectAsState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/downloaddir/DownloadDirScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/downloaddir/DownloadDirScreen.kt
@@ -43,8 +43,9 @@ import io.github.kdroidfilter.ytdlpgui.features.init.InitState
 fun DownloadDirScreen(
     viewModel: OnboardingViewModel = koinViewModel(),
 ) {
+    val downloadDirPath by viewModel.downloadDirPath.collectAsState()
     val state = DownloadDirState(
-        downloadDirPath = viewModel.downloadDirPath.collectAsState().value
+        downloadDirPath = downloadDirPath
     )
     val currentStep by viewModel.currentStep.collectAsState()
     val initState by viewModel.initState.collectAsState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/nocheckcert/NoCheckCertScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/nocheckcert/NoCheckCertScreen.kt
@@ -43,8 +43,9 @@ import io.github.kdroidfilter.ytdlpgui.features.init.InitState
 fun NoCheckCertScreen(
     viewModel: OnboardingViewModel = koinViewModel(),
 ) {
+    val noCheckCertificate by viewModel.noCheckCertificate.collectAsState()
     val state = NoCheckCertState(
-        noCheckCertificate = viewModel.noCheckCertificate.collectAsState().value
+        noCheckCertificate = noCheckCertificate
     )
     val currentStep by viewModel.currentStep.collectAsState()
     val initState by viewModel.initState.collectAsState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/about/AboutScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/about/AboutScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -32,7 +33,7 @@ import ytdlpgui.composeapp.generated.resources.*
 @Composable
 fun AboutScreen() {
     val viewModel = koinViewModel<AboutViewModel>()
-    val state = viewModel.uiState.collectAsState().value
+    val state by viewModel.uiState.collectAsState()
     AboutView(
         state = state,
         onEvent = viewModel::handleEvent,

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsScreen.kt
@@ -43,11 +43,12 @@ import org.koin.compose.viewmodel.koinViewModel
 import ytdlpgui.composeapp.generated.resources.Res
 import ytdlpgui.composeapp.generated.resources.*
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 
 @Composable
 fun SettingsScreen() {
     val viewModel = koinViewModel<SettingsViewModel>()
-    val state = viewModel.uiState.collectAsState().value
+    val state by viewModel.uiState.collectAsState()
     SettingsView(
         state = state,
         onEvent = viewModel::handleEvent,


### PR DESCRIPTION
### Summary

This pull request introduces the following changes:

1. **UI State Handling Refactor:**
   - Replaced `.value` with Kotlin's `collectAsState` across various screens.
   - Removed direct `getString` usage from `HomeViewModel`, improving separation of responsibilities.
   - Introduced `HomeError` enum and mapped it to `stringResource` in the Home view.

