### PR TITLE
- feat(sponsorblock): support ‘default’ + fix: tooltips text

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
@@ -91,6 +91,10 @@
     <string name="settings_embed_thumbnail_mp3_title">Intégrer la miniature dans le MP3</string>
     <string name="settings_embed_thumbnail_mp3_caption">Si activé, intégrer la miniature de la vidéo comme pochette du MP3</string>
 
+    <!-- Paramètres : SponsorBlock -->
+    <string name="settings_sponsorblock_title">Supprimer les segments sponsorisés</string>
+    <string name="settings_sponsorblock_caption">De nombreuses vidéos YouTube contiennent des segments sponsorisés, qui sont généralement des publicités. Cette option les supprime de la vidéo finale</string>
+
     <!-- Paramètres : section Dossier de téléchargement -->
     <string name="settings_download_dir_title">Dossier de téléchargement</string>
     <string name="settings_download_dir_caption">Choisissez le dossier où les téléchargements seront enregistrés par défaut.</string>

--- a/composeApp/src/jvmMain/composeResources/values-he/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-he/strings.xml
@@ -190,4 +190,9 @@
     <string name="settings_reset_dialog_message">פעולה זו תאפס את כל ההגדרות לערכי ברירת המחדל, תמחק את היסטוריית ההורדות ותסיר את קבצי yt-dlp/FFmpeg. קבצים שהורדו לא יושפעו.\n\nהאם להמשיך?</string>
     <string name="settings_reset_dialog_confirm">אפס הכל</string>
     <string name="settings_reset_dialog_cancel">ביטול</string>
+
+    <!-- הגדרות: SponsorBlock -->
+    <string name="settings_sponsorblock_title">הסר קטעי ספונסרים</string>
+    <string name="settings_sponsorblock_caption">סרטוני יוטיוב רבים מכילים קטעי חסות, שהם בדרך כלל פרסומות. אפשרות זו מסירה אותם מהווידאו הסופי</string>
+
 </resources>

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -90,6 +90,10 @@
     <string name="settings_embed_thumbnail_mp3_title">Embed thumbnail in MP3</string>
     <string name="settings_embed_thumbnail_mp3_caption">When enabled, embed the video thumbnail as MP3 cover art</string>
 
+    <!-- Settings: SponsorBlock -->
+    <string name="settings_sponsorblock_title">Remove sponsored segments</string>
+    <string name="settings_sponsorblock_caption">Many YouTube videos contain sponsored segments, which are typically advertisements. This option removes them from the final video</string>
+
     <!-- Settings: Download directory section -->
     <string name="settings_download_dir_title">Download directory</string>
     <string name="settings_download_dir_caption">Choose the folder where downloads will be saved by default.</string>

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/config/SettingsKeys.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/config/SettingsKeys.kt
@@ -15,4 +15,5 @@ object SettingsKeys {
     const val AUTO_LAUNCH_ENABLED = "auto_launch_enabled"
     const val NOTIFY_ON_DOWNLOAD_COMPLETE = "notify_on_download_complete"
     const val ONBOARDING_COMPLETED = "onboarding_completed"
+    const val SPONSORBLOCK_REMOVE = "sponsorblock_remove"
 }

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/design/components/EllipsizedTextWithTooltip.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/design/components/EllipsizedTextWithTooltip.kt
@@ -47,7 +47,6 @@ fun EllipsizedTextWithTooltip(
                     Text(
                         text = text,
                         modifier = Modifier.padding(8.dp),
-                        color = Color.White
                     )
 
             },

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/data/SettingsRepository.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/data/SettingsRepository.kt
@@ -48,6 +48,9 @@ class SettingsRepository(
     private val _autoLaunchEnabled = MutableStateFlow(settings.getBoolean(SettingsKeys.AUTO_LAUNCH_ENABLED, false))
     val autoLaunchEnabled: StateFlow<Boolean> = _autoLaunchEnabled.asStateFlow()
 
+    private val _sponsorBlockRemove = MutableStateFlow(settings.getBoolean(SettingsKeys.SPONSORBLOCK_REMOVE, false))
+    val sponsorBlockRemove: StateFlow<Boolean> = _sponsorBlockRemove.asStateFlow()
+
     init {
         // Apply initial settings to dependencies
         applyToYtDlpWrapper()
@@ -102,6 +105,12 @@ class SettingsRepository(
         settings.putBoolean(SettingsKeys.NOTIFY_ON_DOWNLOAD_COMPLETE, enabled)
     }
 
+    fun setSponsorBlockRemove(enabled: Boolean) {
+        _sponsorBlockRemove.value = enabled
+        settings.putBoolean(SettingsKeys.SPONSORBLOCK_REMOVE, enabled)
+        ytDlpWrapper.sponsorBlockRemove = enabled
+    }
+
     fun setOnboardingCompleted(completed: Boolean) {
         settings.putBoolean(SettingsKeys.ONBOARDING_COMPLETED, completed)
     }
@@ -124,6 +133,7 @@ class SettingsRepository(
         _clipboardMonitoringEnabled.value = settings.getBoolean(SettingsKeys.CLIPBOARD_MONITORING_ENABLED, true)
         _notifyOnComplete.value = settings.getBoolean(SettingsKeys.NOTIFY_ON_DOWNLOAD_COMPLETE, true)
         _autoLaunchEnabled.value = settings.getBoolean(SettingsKeys.AUTO_LAUNCH_ENABLED, false)
+        _sponsorBlockRemove.value = settings.getBoolean(SettingsKeys.SPONSORBLOCK_REMOVE, false)
 
         applyToYtDlpWrapper()
         applyToClipboardMonitor()
@@ -166,6 +176,7 @@ class SettingsRepository(
         val path = _downloadDirPath.value
         ytDlpWrapper.downloadDir = path.takeIf { it.isNotBlank() }?.let { File(it) }
         ytDlpWrapper.embedThumbnailInMp3 = _embedThumbnailInMp3.value
+        ytDlpWrapper.sponsorBlockRemove = _sponsorBlockRemove.value
     }
 
     private fun applyToClipboardMonitor() {
@@ -191,6 +202,7 @@ class SettingsRepository(
         _clipboardMonitoringEnabled.value = true
         _notifyOnComplete.value = true
         _autoLaunchEnabled.value = false
+        _sponsorBlockRemove.value = false
 
         // Apply defaults to dependencies
         applyToYtDlpWrapper()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsEvents.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsEvents.kt
@@ -13,6 +13,7 @@ sealed class SettingsEvents {
     data class SetDownloadDir(val path: String) : SettingsEvents()
     data class SetClipboardMonitoring(val enabled: Boolean) : SettingsEvents()
     data class SetAutoLaunchEnabled(val enabled: Boolean) : SettingsEvents()
+    data class SetSponsorBlockRemove(val enabled: Boolean) : SettingsEvents()
     data class PickDownloadDir(val title: String) : SettingsEvents()
     data object ResetToDefaults : SettingsEvents()
 }

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsScreen.kt
@@ -2,54 +2,23 @@ package io.github.kdroidfilter.ytdlpgui.features.system.settings
 
 import androidx.compose.desktop.ui.tooling.preview.Preview
 import androidx.compose.foundation.VerticalScrollbar
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollbarAdapter
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import io.github.composefluent.component.Button
-import io.github.composefluent.component.CardExpanderItem
-import io.github.composefluent.component.DropDownButton
-import io.github.composefluent.component.FlyoutPlacement
-import io.github.composefluent.component.Icon
-import io.github.composefluent.component.MenuFlyoutContainer
-import io.github.composefluent.component.MenuFlyoutItem
-import io.github.composefluent.component.Text
+import io.github.composefluent.component.*
 import io.github.composefluent.icons.Icons
-import io.github.composefluent.icons.filled.DocumentEdit
-import io.github.composefluent.icons.filled.MusicNote1
-import io.github.composefluent.icons.filled.OpenFolder
-import io.github.composefluent.icons.filled.TopSpeed
-import io.github.composefluent.icons.regular.Clipboard
-import io.github.composefluent.icons.regular.Cookies
-import io.github.composefluent.icons.regular.LockShield
-import io.github.composefluent.icons.regular.Power
+import io.github.composefluent.icons.filled.*
+import io.github.composefluent.icons.regular.*
 import io.github.kdroidfilter.ytdlpgui.core.design.components.BrowserSelector
 import io.github.kdroidfilter.ytdlpgui.core.design.components.EllipsizedTextWithTooltip
 import io.github.kdroidfilter.ytdlpgui.core.design.components.Switcher
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
-import ytdlpgui.composeapp.generated.resources.Res
 import ytdlpgui.composeapp.generated.resources.*
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import io.github.composefluent.component.ContentDialog
-import io.github.composefluent.icons.filled.DeleteDismiss
-import io.github.composefluent.icons.regular.Warning
 
 @Composable
 fun SettingsScreen() {
@@ -92,6 +61,12 @@ fun SettingsView(
                 EmbedThumbnailInMp3Setting(
                     embedThumbnailInMp3 = state.embedThumbnailInMp3,
                     onEmbedThumbnailChange = { onEvent(SettingsEvents.SetEmbedThumbnailInMp3(it)) },
+                )
+            }
+            item {
+                SponsorBlockRemoveSetting(
+                    sponsorBlockRemove = state.sponsorBlockRemove,
+                    onSponsorBlockChange = { onEvent(SettingsEvents.SetSponsorBlockRemove(it)) },
                 )
             }
             item {
@@ -250,6 +225,40 @@ private fun EmbedThumbnailInMp3Setting(
 @Composable
 fun EmbedThumbnailInMp3SettingPreview() {
     EmbedThumbnailInMp3Setting(embedThumbnailInMp3 = true, onEmbedThumbnailChange = {})
+}
+
+@Composable
+private fun SponsorBlockRemoveSetting(
+    sponsorBlockRemove: Boolean,
+    onSponsorBlockChange: (Boolean) -> Unit,
+) {
+    CardExpanderItem(
+        heading = {
+            Text(
+                stringResource(Res.string.settings_sponsorblock_title),
+                modifier = Modifier.fillMaxWidth(0.8f)
+            )
+        },
+        caption = {
+            EllipsizedTextWithTooltip(
+                text = stringResource(Res.string.settings_sponsorblock_caption),
+                modifier = Modifier.fillMaxWidth(0.8f)
+            )
+        },
+        icon = { Icon(Icons.Filled.Cut, null) },
+        trailing = {
+            Switcher(
+                checked = sponsorBlockRemove,
+                onCheckStateChange = onSponsorBlockChange,
+            )
+        }
+    )
+}
+
+@Preview
+@Composable
+fun SponsorBlockRemoveSettingPreview() {
+    SponsorBlockRemoveSetting(sponsorBlockRemove = true, onSponsorBlockChange = {})
 }
 
 @Composable

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsState.kt
@@ -15,6 +15,7 @@ data class SettingsState(
     val clipboardMonitoringEnabled: Boolean = false,
     val autoLaunchEnabled: Boolean = false,
     val notifyOnComplete: Boolean = true,
+    val sponsorBlockRemove: Boolean = false,
 ) {
     companion object {
         val defaultState = SettingsState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsViewModel.kt
@@ -43,6 +43,7 @@ class SettingsViewModel(
     val clipboardMonitoring: StateFlow<Boolean> = settingsRepository.clipboardMonitoringEnabled
     val notifyOnComplete: StateFlow<Boolean> = settingsRepository.notifyOnComplete
     val autoLaunchEnabled: StateFlow<Boolean> = settingsRepository.autoLaunchEnabled
+    val sponsorBlockRemove: StateFlow<Boolean> = settingsRepository.sponsorBlockRemove
 
     // Note: This ViewModel uses a combined state from multiple sources, so we override uiState
     override val uiState = combine(
@@ -56,6 +57,7 @@ class SettingsViewModel(
         clipboardMonitoring,
         autoLaunchEnabled,
         notifyOnComplete,
+        sponsorBlockRemove,
     ) { values: Array<Any?> ->
         val loading = values[0] as Boolean
         val noCheck = values[1] as Boolean
@@ -67,6 +69,7 @@ class SettingsViewModel(
         val clipboard = values[7] as Boolean
         val autoLaunch = values[8] as Boolean
         val notify = values[9] as Boolean
+        val sponsorBlock = values[10] as Boolean
         SettingsState(
             isLoading = loading,
             noCheckCertificate = noCheck,
@@ -78,6 +81,7 @@ class SettingsViewModel(
             clipboardMonitoringEnabled = clipboard,
             autoLaunchEnabled = autoLaunch,
             notifyOnComplete = notify,
+            sponsorBlockRemove = sponsorBlock,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -123,6 +127,9 @@ class SettingsViewModel(
             }
             is SettingsEvents.SetAutoLaunchEnabled -> {
                 viewModelScope.launch { settingsRepository.setAutoLaunchEnabled(event.enabled) }
+            }
+            is SettingsEvents.SetSponsorBlockRemove -> {
+                settingsRepository.setSponsorBlockRemove(event.enabled)
             }
             is SettingsEvents.PickDownloadDir -> {
                 viewModelScope.launch {

--- a/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/YtDlpWrapper.kt
+++ b/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/YtDlpWrapper.kt
@@ -77,6 +77,12 @@ class YtDlpWrapper {
      */
     var embedThumbnailInMp3: Boolean = true
 
+    /**
+     * Controls whether to remove sponsored segments from downloaded videos.
+     * When true, yt-dlp is invoked with "--sponsorblock-remove default".
+     */
+    var sponsorBlockRemove: Boolean = false
+
     private val httpClient = KtorConfig.createHttpClient()
     private val ytdlpFetcher = GitHubReleaseFetcher(owner = "yt-dlp", repo = "yt-dlp", httpClient = httpClient)
     private val ffmpegFetcher = GitHubReleaseFetcher(owner = "yt-dlp", repo = "FFmpeg-Builds", httpClient = httpClient)
@@ -689,7 +695,8 @@ class YtDlpWrapper {
             timeout = timeout,
             targetContainer = "mp4",
             allowRecode = recodeIfNeeded,
-            subtitles = subtitles
+            subtitles = subtitles,
+            sponsorBlockRemove = this.sponsorBlockRemove
         )
         return download(url, opts, onEvent)
     }

--- a/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/core/Options.kt
+++ b/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/core/Options.kt
@@ -27,6 +27,7 @@ data class SubtitleOptions(
  * @property targetContainer The desired container format (e.g., "mp4"). Null to keep the original.
  * @property allowRecode If true, allows re-encoding if remuxing into the target container is not possible.
  * @property subtitles Subtitle download configuration. Null to skip subtitle downloading.
+ * @property sponsorBlockRemove If true, removes SponsorBlock segments (default categories).
  */
 data class Options(
     val format: String? = null,
@@ -37,5 +38,6 @@ data class Options(
     val timeout: Duration? = Duration.ofMinutes(30),
     val targetContainer: String? = null,
     val allowRecode: Boolean = false,
-    val subtitles: SubtitleOptions? = null  // NEW: Subtitle configuration
+    val subtitles: SubtitleOptions? = null,  // NEW: Subtitle configuration
+    val sponsorBlockRemove: Boolean = false  // NEW: SponsorBlock segment removal
 )

--- a/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/util/NetAndArchive.kt
+++ b/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/util/NetAndArchive.kt
@@ -106,6 +106,11 @@ object NetAndArchive {
         // Subtitles
         options.subtitles?.let { subOpts -> handleSubtitleOptions(cmd, subOpts) }
 
+        // SponsorBlock
+        if (options.sponsorBlockRemove) {
+            cmd.addAll(listOf("--sponsorblock-remove", "default"))
+        }
+
         // Container enforcement (kept)
         options.targetContainer?.let { container ->
             if (container.equals("mp4", ignoreCase = true)) {

--- a/ytdlp/src/jvmTest/kotlin/io/github/kdroidfilter/ytdlp/NetAndArchiveBuildCommandTest.kt
+++ b/ytdlp/src/jvmTest/kotlin/io/github/kdroidfilter/ytdlp/NetAndArchiveBuildCommandTest.kt
@@ -68,5 +68,38 @@ class NetAndArchiveBuildCommandTest {
         assertTrue(cmdRemux.contains("--remux-video"))
         assertTrue(cmdRecode.contains("--recode-video"))
     }
+
+    @Test
+    fun buildCommand_includesSponsorBlockRemove_whenEnabled() {
+        val opts = Options(
+            outputTemplate = "%(title)s.%(ext)s",
+            sponsorBlockRemove = true
+        )
+        val cmd = NetAndArchive.buildCommand(
+            ytDlpPath = "/usr/bin/yt-dlp",
+            ffmpegPath = null,
+            url = "https://example.com/video",
+            options = opts,
+            downloadDir = null
+        )
+        assertTrue(cmd.contains("--sponsorblock-remove"))
+        assertTrue(cmd.contains("default"))
+    }
+
+    @Test
+    fun buildCommand_omitsSponsorBlock_whenDisabled() {
+        val opts = Options(
+            outputTemplate = "%(title)s.%(ext)s",
+            sponsorBlockRemove = false
+        )
+        val cmd = NetAndArchive.buildCommand(
+            ytDlpPath = "/usr/bin/yt-dlp",
+            ffmpegPath = null,
+            url = "https://example.com/video",
+            options = opts,
+            downloadDir = null
+        )
+        assertTrue(!cmd.contains("--sponsorblock-remove"))
+    }
 }
 


### PR DESCRIPTION
- Added the SponsorBlock option (default category) to remove sponsored segments during downloads.
- Fixed text display in tooltips in light mode.