### PR TITLE
Add concurrent fragment download option to settings

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
@@ -94,6 +94,10 @@
     <!-- Paramètres : SponsorBlock -->
     <string name="settings_sponsorblock_title">Supprimer les segments sponsorisés</string>
     <string name="settings_sponsorblock_caption">De nombreuses vidéos YouTube contiennent des segments sponsorisés, qui sont généralement des publicités. Cette option les supprime de la vidéo finale</string>
+    <!-- Paramètres : Fragments concurrents -->
+    <string name="settings_concurrent_fragments_title">Threads de téléchargement de fragments</string>
+    <string name="settings_concurrent_fragments_caption">Fractionne le fichier et télécharge chaque partie simultanément, accélérant grandement les téléchargements. Non recommandé : peut entraîner un bannissement</string>
+
 
     <!-- Paramètres : section Dossier de téléchargement -->
     <string name="settings_download_dir_title">Dossier de téléchargement</string>

--- a/composeApp/src/jvmMain/composeResources/values-he/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-he/strings.xml
@@ -194,5 +194,9 @@
     <!-- הגדרות: SponsorBlock -->
     <string name="settings_sponsorblock_title">הסר קטעי ספונסרים</string>
     <string name="settings_sponsorblock_caption">סרטוני יוטיוב רבים מכילים קטעי חסות, שהם בדרך כלל פרסומות. אפשרות זו מסירה אותם מהווידאו הסופי</string>
+    <!-- הגדרות: פיצולי קבצים מקבילים -->
+    <string name="settings_concurrent_fragments_title">חוטי הורדת פיצולים</string>
+    <string name="settings_concurrent_fragments_caption">מפצל את הקובץ ומוריד כל חלק בו-זמנית, מאיץ מאוד את ההורדות. לא מומלץ: עלול להוביל לחסימת חשבון</string>
+
 
 </resources>

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -94,6 +94,10 @@
     <string name="settings_sponsorblock_title">Remove sponsored segments</string>
     <string name="settings_sponsorblock_caption">Many YouTube videos contain sponsored segments, which are typically advertisements. This option removes them from the final video</string>
 
+    <!-- Settings: Concurrent fragments -->
+    <string name="settings_concurrent_fragments_title">Fragment download threads</string>
+    <string name="settings_concurrent_fragments_caption">Splits the file and downloads each part simultaneously, greatly speeding up downloads. Not recommended: may result in account bans</string>
+
     <!-- Settings: Download directory section -->
     <string name="settings_download_dir_title">Download directory</string>
     <string name="settings_download_dir_caption">Choose the folder where downloads will be saved by default.</string>

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/config/SettingsKeys.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/config/SettingsKeys.kt
@@ -16,4 +16,5 @@ object SettingsKeys {
     const val NOTIFY_ON_DOWNLOAD_COMPLETE = "notify_on_download_complete"
     const val ONBOARDING_COMPLETED = "onboarding_completed"
     const val SPONSORBLOCK_REMOVE = "sponsorblock_remove"
+    const val CONCURRENT_FRAGMENTS = "concurrent_fragments"
 }

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/data/SettingsRepository.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/data/SettingsRepository.kt
@@ -51,6 +51,9 @@ class SettingsRepository(
     private val _sponsorBlockRemove = MutableStateFlow(settings.getBoolean(SettingsKeys.SPONSORBLOCK_REMOVE, false))
     val sponsorBlockRemove: StateFlow<Boolean> = _sponsorBlockRemove.asStateFlow()
 
+    private val _concurrentFragments = MutableStateFlow(settings.getInt(SettingsKeys.CONCURRENT_FRAGMENTS, 1).coerceIn(1, 5))
+    val concurrentFragments: StateFlow<Int> = _concurrentFragments.asStateFlow()
+
     init {
         // Apply initial settings to dependencies
         applyToYtDlpWrapper()
@@ -111,6 +114,13 @@ class SettingsRepository(
         ytDlpWrapper.sponsorBlockRemove = enabled
     }
 
+    fun setConcurrentFragments(count: Int) {
+        val clamped = count.coerceIn(1, 5)
+        _concurrentFragments.value = clamped
+        settings.putInt(SettingsKeys.CONCURRENT_FRAGMENTS, clamped)
+        ytDlpWrapper.concurrentFragments = clamped
+    }
+
     fun setOnboardingCompleted(completed: Boolean) {
         settings.putBoolean(SettingsKeys.ONBOARDING_COMPLETED, completed)
     }
@@ -134,6 +144,7 @@ class SettingsRepository(
         _notifyOnComplete.value = settings.getBoolean(SettingsKeys.NOTIFY_ON_DOWNLOAD_COMPLETE, true)
         _autoLaunchEnabled.value = settings.getBoolean(SettingsKeys.AUTO_LAUNCH_ENABLED, false)
         _sponsorBlockRemove.value = settings.getBoolean(SettingsKeys.SPONSORBLOCK_REMOVE, false)
+        _concurrentFragments.value = settings.getInt(SettingsKeys.CONCURRENT_FRAGMENTS, 1).coerceIn(1, 5)
 
         applyToYtDlpWrapper()
         applyToClipboardMonitor()
@@ -177,6 +188,7 @@ class SettingsRepository(
         ytDlpWrapper.downloadDir = path.takeIf { it.isNotBlank() }?.let { File(it) }
         ytDlpWrapper.embedThumbnailInMp3 = _embedThumbnailInMp3.value
         ytDlpWrapper.sponsorBlockRemove = _sponsorBlockRemove.value
+        ytDlpWrapper.concurrentFragments = _concurrentFragments.value
     }
 
     private fun applyToClipboardMonitor() {
@@ -203,6 +215,7 @@ class SettingsRepository(
         _notifyOnComplete.value = true
         _autoLaunchEnabled.value = false
         _sponsorBlockRemove.value = false
+        _concurrentFragments.value = 1
 
         // Apply defaults to dependencies
         applyToYtDlpWrapper()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsEvents.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsEvents.kt
@@ -14,6 +14,7 @@ sealed class SettingsEvents {
     data class SetClipboardMonitoring(val enabled: Boolean) : SettingsEvents()
     data class SetAutoLaunchEnabled(val enabled: Boolean) : SettingsEvents()
     data class SetSponsorBlockRemove(val enabled: Boolean) : SettingsEvents()
+    data class SetConcurrentFragments(val count: Int) : SettingsEvents()
     data class PickDownloadDir(val title: String) : SettingsEvents()
     data object ResetToDefaults : SettingsEvents()
 }

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsScreen.kt
@@ -70,6 +70,12 @@ fun SettingsView(
                 )
             }
             item {
+                ConcurrentFragmentsSetting(
+                    concurrentFragments = state.concurrentFragments,
+                    onConcurrentFragmentsSelected = { onEvent(SettingsEvents.SetConcurrentFragments(it)) },
+                )
+            }
+            item {
                 ParallelDownloadsSetting(
                     parallelDownloads = state.parallelDownloads,
                     onParallelDownloadsSelected = { onEvent(SettingsEvents.SetParallelDownloads(it)) },
@@ -262,12 +268,57 @@ fun SponsorBlockRemoveSettingPreview() {
 }
 
 @Composable
+private fun ConcurrentFragmentsSetting(
+    concurrentFragments: Int,
+    onConcurrentFragmentsSelected: (Int) -> Unit,
+) {
+    val options = (1..5).toList()
+    val items = options.map { it.toString() }
+    var selected by remember(concurrentFragments) {
+        mutableStateOf(options.indexOf(concurrentFragments))
+    }
+
+    CardExpanderItem(
+        heading = { Text(stringResource(Res.string.settings_concurrent_fragments_title), modifier = Modifier.fillMaxWidth(0.75f)) },
+        caption = {
+            EllipsizedTextWithTooltip(
+                text = stringResource(Res.string.settings_concurrent_fragments_caption),
+                modifier = Modifier.fillMaxWidth(0.75f)
+            )
+        },
+        icon = { Icon(Icons.Filled.Flash, null) },
+        trailing = {
+            ComboBox(
+                modifier = Modifier.width(80.dp),
+                header = null,
+                placeholder = "",
+                selected = selected,
+                items = items,
+                onSelectionChange = { index, _ ->
+                    selected = index
+                    onConcurrentFragmentsSelected(options[index])
+                }
+            )
+        }
+    )
+}
+
+@Preview
+@Composable
+fun ConcurrentFragmentsSettingPreview() {
+    ConcurrentFragmentsSetting(concurrentFragments = 1, onConcurrentFragmentsSelected = {})
+}
+
+@Composable
 private fun ParallelDownloadsSetting(
     parallelDownloads: Int,
     onParallelDownloadsSelected: (Int) -> Unit,
 ) {
     val options = (1..5).toList()
-    val selectionLabel = parallelDownloads.toString()
+    val items = options.map { it.toString() }
+    var selected by remember(parallelDownloads) {
+        mutableStateOf(options.indexOf(parallelDownloads))
+    }
 
     CardExpanderItem(
         heading = { Text(stringResource(Res.string.settings_parallel_downloads_title)) },
@@ -279,34 +330,16 @@ private fun ParallelDownloadsSetting(
         },
         icon = { Icon(Icons.Filled.TopSpeed, null) },
         trailing = {
-            MenuFlyoutContainer(
-                flyout = {
-                    options.forEach { count ->
-                        MenuFlyoutItem(
-                            modifier = Modifier.width(56.dp),
-                            text = { Text(count.toString()) },
-                            onClick = {
-                                onParallelDownloadsSelected(count)
-                                isFlyoutVisible = false
-                            }
-                        )
-                    }
-                },
-                content = {
-                    DropDownButton(
-                        modifier = Modifier.fillMaxWidth().padding(horizontal = 1.dp),
-                        onClick = { isFlyoutVisible = !isFlyoutVisible },
-                        content = {
-                            Row(
-                                modifier = Modifier.fillMaxWidth(0.9f),
-                                horizontalArrangement = Arrangement.SpaceEvenly
-                            ) {
-                                Text(selectionLabel)
-                            }
-                        },
-                    )
-                },
-                placement = FlyoutPlacement.Bottom
+            ComboBox(
+                modifier = Modifier.width(80.dp),
+                header = null,
+                placeholder = "",
+                selected = selected,
+                items = items,
+                onSelectionChange = { index, _ ->
+                    selected = index
+                    onParallelDownloadsSelected(options[index])
+                }
             )
         }
     )

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsState.kt
@@ -16,6 +16,7 @@ data class SettingsState(
     val autoLaunchEnabled: Boolean = false,
     val notifyOnComplete: Boolean = true,
     val sponsorBlockRemove: Boolean = false,
+    val concurrentFragments: Int = 1,
 ) {
     companion object {
         val defaultState = SettingsState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsViewModel.kt
@@ -44,6 +44,7 @@ class SettingsViewModel(
     val notifyOnComplete: StateFlow<Boolean> = settingsRepository.notifyOnComplete
     val autoLaunchEnabled: StateFlow<Boolean> = settingsRepository.autoLaunchEnabled
     val sponsorBlockRemove: StateFlow<Boolean> = settingsRepository.sponsorBlockRemove
+    val concurrentFragments: StateFlow<Int> = settingsRepository.concurrentFragments
 
     // Note: This ViewModel uses a combined state from multiple sources, so we override uiState
     override val uiState = combine(
@@ -58,6 +59,7 @@ class SettingsViewModel(
         autoLaunchEnabled,
         notifyOnComplete,
         sponsorBlockRemove,
+        concurrentFragments,
     ) { values: Array<Any?> ->
         val loading = values[0] as Boolean
         val noCheck = values[1] as Boolean
@@ -70,6 +72,7 @@ class SettingsViewModel(
         val autoLaunch = values[8] as Boolean
         val notify = values[9] as Boolean
         val sponsorBlock = values[10] as Boolean
+        val concurrent = values[11] as Int
         SettingsState(
             isLoading = loading,
             noCheckCertificate = noCheck,
@@ -82,6 +85,7 @@ class SettingsViewModel(
             autoLaunchEnabled = autoLaunch,
             notifyOnComplete = notify,
             sponsorBlockRemove = sponsorBlock,
+            concurrentFragments = concurrent,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -130,6 +134,9 @@ class SettingsViewModel(
             }
             is SettingsEvents.SetSponsorBlockRemove -> {
                 settingsRepository.setSponsorBlockRemove(event.enabled)
+            }
+            is SettingsEvents.SetConcurrentFragments -> {
+                settingsRepository.setConcurrentFragments(event.count)
             }
             is SettingsEvents.PickDownloadDir -> {
                 viewModelScope.launch {

--- a/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/YtDlpWrapper.kt
+++ b/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/YtDlpWrapper.kt
@@ -83,6 +83,13 @@ class YtDlpWrapper {
      */
     var sponsorBlockRemove: Boolean = false
 
+    /**
+     * Number of threads for downloading m3u8/mpd fragments in parallel (1-5).
+     * Values > 1 can significantly speed up downloads but may risk rate limiting.
+     * Default: 1 (disabled).
+     */
+    var concurrentFragments: Int = 1
+
     private val httpClient = KtorConfig.createHttpClient()
     private val ytdlpFetcher = GitHubReleaseFetcher(owner = "yt-dlp", repo = "yt-dlp", httpClient = httpClient)
     private val ffmpegFetcher = GitHubReleaseFetcher(owner = "yt-dlp", repo = "FFmpeg-Builds", httpClient = httpClient)
@@ -696,7 +703,8 @@ class YtDlpWrapper {
             targetContainer = "mp4",
             allowRecode = recodeIfNeeded,
             subtitles = subtitles,
-            sponsorBlockRemove = this.sponsorBlockRemove
+            sponsorBlockRemove = this.sponsorBlockRemove,
+            concurrentFragments = this.concurrentFragments
         )
         return download(url, opts, onEvent)
     }

--- a/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/core/Options.kt
+++ b/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/core/Options.kt
@@ -28,6 +28,7 @@ data class SubtitleOptions(
  * @property allowRecode If true, allows re-encoding if remuxing into the target container is not possible.
  * @property subtitles Subtitle download configuration. Null to skip subtitle downloading.
  * @property sponsorBlockRemove If true, removes SponsorBlock segments (default categories).
+ * @property concurrentFragments Number of threads for downloading m3u8/mpd fragments in parallel (1-5). 1 = disabled.
  */
 data class Options(
     val format: String? = null,
@@ -39,5 +40,6 @@ data class Options(
     val targetContainer: String? = null,
     val allowRecode: Boolean = false,
     val subtitles: SubtitleOptions? = null,  // NEW: Subtitle configuration
-    val sponsorBlockRemove: Boolean = false  // NEW: SponsorBlock segment removal
+    val sponsorBlockRemove: Boolean = false,  // NEW: SponsorBlock segment removal
+    val concurrentFragments: Int = 1  // NEW: Multi-threaded fragment downloads
 )

--- a/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/util/NetAndArchive.kt
+++ b/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/util/NetAndArchive.kt
@@ -111,6 +111,11 @@ object NetAndArchive {
             cmd.addAll(listOf("--sponsorblock-remove", "default"))
         }
 
+        // Concurrent fragments
+        if (options.concurrentFragments > 1) {
+            cmd.addAll(listOf("--concurrent-fragments", options.concurrentFragments.coerceIn(1, 5).toString()))
+        }
+
         // Container enforcement (kept)
         options.targetContainer?.let { container ->
             if (container.equals("mp4", ignoreCase = true)) {


### PR DESCRIPTION
Adds a new option to control the number of concurrent fragments downloaded in yt-dlp. This feature can improve download speeds for certain video formats like HLS/m3u8.  
Includes UI enhancements with ComboBox integration for consistency and necessary backend wiring.