### PR TITLE
Add search bar in download history UI

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
@@ -153,6 +153,7 @@
     <!-- Écran de téléchargement (historique et en cours) -->
     <string name="download_clear_history">Vider l'historique</string>
     <string name="tooltip_clear_history">Vider l'historique</string>
+    <string name="download_search_placeholder">Rechercher dans l'historique</string>
     <string name="open_directory">Ouvrir le dossier</string>
     <string name="tooltip_open_directory">Ouvrir le dossier</string>
     <string name="delete_element">Supprimer cet élément</string>

--- a/composeApp/src/jvmMain/composeResources/values-he/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-he/strings.xml
@@ -104,6 +104,7 @@
     <!-- מסך הורדות (היסטוריה ובתהליך) -->
     <string name="download_clear_history">נקה היסטוריה</string>
     <string name="tooltip_clear_history">נקה היסטוריה</string>
+    <string name="download_search_placeholder">חפש בהיסטוריה</string>
     <string name="open_directory">פתח תיקייה</string>
     <string name="tooltip_open_directory">פתח תיקייה</string>
     <string name="delete_element">מחק פריט זה</string>

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -159,6 +159,7 @@
     <!-- Download screen (history and in-progress) -->
     <string name="download_clear_history">Clear history</string>
     <string name="tooltip_clear_history">Clear history</string>
+    <string name="download_search_placeholder">Search history</string>
     <string name="open_directory">Open directory</string>
     <string name="tooltip_open_directory">Open directory</string>
     <string name="delete_element">Delete this item</string>

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadEvents.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadEvents.kt
@@ -10,4 +10,5 @@ sealed class DownloadEvents {
     data object DismissErrorDialog : DownloadEvents()
     data class DismissFailed(val id: String) : DownloadEvents()
     data object DismissUpdateInfoBar : DownloadEvents()
+    data class UpdateSearchQuery(val query: String) : DownloadEvents()
 }

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadState.kt
@@ -17,6 +17,10 @@ data class DownloadState(
     val updateVersion: String? = null,
     val updateUrl: String? = null,
     val updateBody: String? = null,
+    // UI: history search
+    val searchQuery: String = "",
+    // Whether any history exists (pre-filter)
+    val hasAnyHistory: Boolean = false,
 ) {
     companion object {
         val emptyState = DownloadState()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
 import java.io.File
+import java.util.Locale
 
 class DownloadViewModel(
     private val downloadManager: DownloadManager,
@@ -33,6 +34,10 @@ class DownloadViewModel(
 
     val items: StateFlow<List<DownloadManager.DownloadItem>> = downloadManager.items
     val history: StateFlow<List<DownloadHistoryRepository.HistoryItem>> = historyRepository.history
+
+    // Search query for history filtering
+    private val _searchQuery = MutableStateFlow("")
+    val searchQuery = _searchQuery.asStateFlow()
 
     // Availability of output directories by history id (derived from history)
     val directoryAvailability = history.map { list ->
@@ -56,6 +61,8 @@ class DownloadViewModel(
         val history: List<DownloadHistoryRepository.HistoryItem>,
         val dirAvail: Map<String, Boolean>,
         val errorItem: DownloadManager.DownloadItem?,
+        val hasAnyHistory: Boolean,
+        val searchQuery: String,
     )
 
     // Note: This ViewModel uses a combined state from multiple sources, so we override uiState
@@ -66,7 +73,24 @@ class DownloadViewModel(
         directoryAvailability,
         errorDialogItem,
     ) { loading, itemsList, historyList, dirAvail, errorItem ->
-        Base(loading, itemsList, historyList, dirAvail, errorItem)
+        Base(
+            loading = loading,
+            items = itemsList,
+            history = historyList,
+            dirAvail = dirAvail,
+            errorItem = errorItem,
+            hasAnyHistory = historyList.isNotEmpty(),
+            searchQuery = "",
+        )
+    }.combine(searchQuery) { base, query ->
+        val q = query.trim().lowercase(Locale.getDefault())
+        val filteredHistory = if (q.isEmpty()) base.history else base.history.filter { h ->
+            val title = h.videoInfo?.title?.lowercase(Locale.getDefault()) ?: ""
+            val url = h.url.lowercase(Locale.getDefault())
+            val path = h.outputPath?.lowercase(Locale.getDefault()) ?: ""
+            title.contains(q) || url.contains(q) || path.contains(q)
+        }
+        base.copy(history = filteredHistory, searchQuery = query)
     }.combine(initViewModel.uiState) { base, initState ->
         DownloadState(
             isLoading = base.loading,
@@ -74,6 +98,8 @@ class DownloadViewModel(
             history = base.history,
             directoryAvailability = base.dirAvail,
             errorDialogItem = base.errorItem,
+            searchQuery = base.searchQuery,
+            hasAnyHistory = base.hasAnyHistory,
             updateAvailable = initState.updateAvailable && !initState.updateDismissed && initState.latestVersion != null && initState.downloadUrl != null,
             updateVersion = initState.latestVersion,
             updateUrl = initState.downloadUrl,
@@ -116,6 +142,9 @@ class DownloadViewModel(
             }
             DownloadEvents.DismissUpdateInfoBar -> {
                 initViewModel.dismissUpdateInfo()
+            }
+            is DownloadEvents.UpdateSearchQuery -> {
+                _searchQuery.value = event.query
             }
         }
     }


### PR DESCRIPTION
### Summary of Changes

- Introduced a search bar in the download history next to the clear-history button.
- Added functionality to filter history by title, URL, or file path in a case-insensitive manner.
- Updated UI to include a localized placeholder message supporting languages like English, French, and Hebrew. 

### Testing

- Verify that the search functionality filters correctly based on title, URL, and file path.
- Ensure placeholder text displays as expected in all supported languages.
- Test clear-history button functionality alongside the search bar to ensure no conflicts. 

### Notes

No issues reported or linked to this commit. Further UX enhancements can