### PR TITLE
Fix notification logic for clipboard onboarding

### DIFF
--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/di/AppGraph.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/di/AppGraph.kt
@@ -121,12 +121,14 @@ interface AppGraph {
         trayAppState: TrayAppState,
         supportedSitesRepository: SupportedSitesRepository,
         navigationEventBus: NavigationEventBus,
+        ytDlpWrapper: YtDlpWrapper,
     ): ClipboardMonitorManager {
         val manager = ClipboardMonitorManager(
             settingsRepository,
             trayAppState,
             supportedSitesRepository,
             navigationEventBus,
+            ytDlpWrapper,
         )
         // Connect SettingsRepository to ClipboardMonitorManager after creation
         settingsRepository.setClipboardMonitorManager(manager)


### PR DESCRIPTION
Improve clipboard notification behavior by checking if onboarding is completed and yt-dlp is initialized before sending notifications. This ensures proper functionality in