### PR TITLE
Fix onboarding error handling and improve localization

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
@@ -176,6 +176,10 @@
     <!-- Infos application -->
     <string name="app_version_label">Version de l'application : %1$s</string>
     
+    <!-- Onboarding fin : gestion des erreurs -->
+    <string name="onboarding_finish_retry">Réessayer le téléchargement</string>
+    <string name="onboarding_finish_error_hint">Vous pouvez continuer ; AeroDL continuera d’essayer en arrière-plan.</string>
+    
     <!-- Paramètres : Surveillance du presse-papiers -->
     <string name="settings_clipboard_monitoring_title">Surveillance du presse-papiers</string>
     <string name="settings_clipboard_monitoring_caption">Lorsqu'activé, copier un lien vidéo supporté enverra une notification demandant si vous voulez le télécharger.</string>

--- a/composeApp/src/jvmMain/composeResources/values-he/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-he/strings.xml
@@ -95,6 +95,10 @@
     <string name="onboarding_finish_ready_title">קדימה!</string>
     <string name="onboarding_finish_ready_message">הכל מוכן. כעת תוכלו להתחיל להשתמש ב-AeroDL.</string>
     <string name="onboarding_finish_ready_button">התחל</string>
+    
+    <!-- סיום תהליך ההגדרה: טיפול בשגיאות -->
+    <string name="onboarding_finish_retry">נסה להוריד שוב</string>
+    <string name="onboarding_finish_error_hint">אפשר להמשיך; AeroDL תמשיך לנסות ברקע.</string>
     <string name="onboarding_gnome_focus_title">שיפור החוויה ב-GNOME</string>
     <string name="onboarding_gnome_focus_caption">GNOME חוסם מיקוד חלונות כברירת מחדל. אנו ממליצים להתקין את התוסף "Steal My Focus" לחוויה טובה יותר של אפליקציה במגש המערכת.</string>
     <string name="onboarding_gnome_focus_open_extension">פתח דף התוסף</string>

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -183,6 +183,10 @@
 
     <!-- App info -->
     <string name="app_version_label">App version: %1$s</string>
+
+    <!-- Onboarding finish: error handling -->
+    <string name="onboarding_finish_retry">Retry download</string>
+    <string name="onboarding_finish_error_hint">You can continue; AeroDL will keep trying in the background.</string>
     
     <!-- Settings: Notifications -->
     <string name="settings_notify_on_complete_title">Download completion notifications</string>

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/design/components/TerminalView.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/design/components/TerminalView.kt
@@ -1,0 +1,113 @@
+@file:OptIn(ExperimentalFluentApi::class)
+
+package io.github.kdroidfilter.ytdlpgui.core.design.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.github.composefluent.ExperimentalFluentApi
+import io.github.composefluent.FluentTheme
+import io.github.composefluent.component.SubtleButton
+import io.github.composefluent.component.Text
+import io.github.composefluent.component.TooltipBox
+import io.github.composefluent.icons.Icons
+import io.github.composefluent.icons.regular.Copy
+import org.jetbrains.compose.resources.stringResource
+import ytdlpgui.composeapp.generated.resources.Res
+import ytdlpgui.composeapp.generated.resources.copy_error
+
+@Composable
+fun TerminalView(
+    text: String,
+    headerText: String = "Error Output",
+    modifier: Modifier = Modifier,
+) {
+    @Suppress("DEPRECATION")
+    val clipboardManager = LocalClipboardManager.current
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(min = 150.dp, max = 300.dp)
+            .background(
+                Color(0xFF1E1E1E),
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp)
+            )
+            .border(
+                width = 1.dp,
+                color = Color(0xFF3E3E3E),
+                shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp)
+            )
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            // Header
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(Color(0xFF2D2D2D))
+                    .padding(horizontal = 12.dp, vertical = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    headerText,
+                    style = FluentTheme.typography.caption,
+                    color = Color(0xFFB0B0B0),
+                    fontSize = 11.sp
+                )
+
+                // Copy button
+                @OptIn(ExperimentalFoundationApi::class)
+                TooltipBox(tooltip = { Text(stringResource(Res.string.copy_error)) }) {
+                    SubtleButton(
+                        iconOnly = true,
+                        onClick = { clipboardManager.setText(buildAnnotatedString { append(text) }) },
+                        modifier = Modifier.size(24.dp)
+                    ) {
+                        io.github.composefluent.component.Icon(
+                            Icons.Default.Copy,
+                            stringResource(Res.string.copy_error),
+                            tint = Color(0xFFB0B0B0),
+                            modifier = Modifier.size(16.dp)
+                        )
+                    }
+                }
+            }
+
+            // Content
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .padding(12.dp)
+            ) {
+                Text(
+                    text,
+                    style = FluentTheme.typography.caption.copy(
+                        fontFamily = FontFamily.Monospace,
+                        lineHeight = 18.sp
+                    ),
+                    color = Color(0xFFD4D4D4),
+                    fontSize = 12.sp,
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    }
+}
+

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadScreen.kt
@@ -43,6 +43,7 @@ import io.github.composefluent.icons.Icons
 import io.github.composefluent.icons.regular.*
 import io.github.kdroidfilter.ytdlp.util.YouTubeThumbnailHelper
 import io.github.kdroidfilter.ytdlpgui.core.design.components.UpdateInfoBar
+import io.github.kdroidfilter.ytdlpgui.core.design.components.TerminalView
 import io.github.kdroidfilter.ytdlpgui.core.domain.manager.DownloadManager
 import io.github.kdroidfilter.ytdlpgui.data.DownloadHistoryRepository.HistoryItem
 import io.github.kdroidfilter.ytdlpgui.core.design.components.UpdateInfoBar
@@ -243,87 +244,7 @@ private fun ErrorDialog(
     )
 }
 
-@OptIn(ExperimentalFluentApi::class)
-@Composable
-private fun TerminalView(text: String) {
-    @Suppress("DEPRECATION")
-    val clipboardManager = LocalClipboardManager.current
-
-    Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .heightIn(min = 150.dp, max = 300.dp)
-            .background(
-                Color(0xFF1E1E1E), // Dark terminal background
-                shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp)
-            )
-            .border(
-                width = 1.dp,
-                color = Color(0xFF3E3E3E),
-                shape = androidx.compose.foundation.shape.RoundedCornerShape(8.dp)
-            )
-    ) {
-        Column(
-            modifier = Modifier.fillMaxWidth()
-        ) {
-            // Terminal header
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .background(Color(0xFF2D2D2D))
-                    .padding(horizontal = 12.dp, vertical = 8.dp),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    "Error Output",
-                    style = FluentTheme.typography.caption,
-                    color = Color(0xFFB0B0B0),
-                    fontSize = 11.sp
-                )
-
-                // Copy button
-                @OptIn(ExperimentalFoundationApi::class)
-                TooltipBox(tooltip = { Text(stringResource(Res.string.copy_error)) }) {
-                    SubtleButton(
-                        iconOnly = true,
-                        onClick = {
-                            clipboardManager.setText(buildAnnotatedString { append(text) })
-                        },
-                        modifier = Modifier.size(24.dp)
-                    ) {
-                        Icon(
-                            Icons.Default.Copy,
-                            stringResource(Res.string.copy_error),
-                            tint = Color(0xFFB0B0B0),
-                            modifier = Modifier.size(16.dp)
-                        )
-                    }
-                }
-            }
-
-            // Terminal content
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f)
-                    .verticalScroll(rememberScrollState())
-                    .padding(12.dp)
-            ) {
-                Text(
-                    text,
-                    style = FluentTheme.typography.caption.copy(
-                        fontFamily = FontFamily.Monospace,
-                        lineHeight = 18.sp
-                    ),
-                    color = Color(0xFFD4D4D4), // Terminal text color
-                    fontSize = 12.sp,
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
-        }
-    }
-}
+// TerminalView moved to core.design.components.TerminalView for reuse
 
 @Composable
 private fun NoDownloads() {

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/init/InitViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/init/InitViewModel.kt
@@ -256,6 +256,7 @@ class InitViewModel(
                         }
                     }
                     is YtDlpWrapper.InitEvent.Error -> {
+                        isInitializing = false
                         update {
                             copy(
                                 errorMessage = event.message,
@@ -270,6 +271,7 @@ class InitViewModel(
                         }
                     }
                     is YtDlpWrapper.InitEvent.Completed -> {
+                        isInitializing = false
                         update {
                             copy(
                                 checkingYtDlp = false,

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/finish/FinishScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/onboarding/finish/FinishScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -22,6 +23,10 @@ import io.github.kdroidfilter.ytdlpgui.features.init.InitState
 import io.github.kdroidfilter.ytdlpgui.features.onboarding.OnboardingStep
 import io.github.kdroidfilter.ytdlpgui.features.onboarding.OnboardingViewModel
 import io.github.kdroidfilter.ytdlpgui.features.onboarding.components.OnboardingProgress
+import io.github.composefluent.component.ContentDialog
+import io.github.composefluent.component.DialogSize
+import io.github.composefluent.component.SubtleButton
+import io.github.kdroidfilter.ytdlpgui.core.design.components.TerminalView
 import io.github.vinceglb.confettikit.compose.ConfettiKit
 import io.github.vinceglb.confettikit.core.Party
 import io.github.vinceglb.confettikit.core.emitter.Emitter
@@ -29,6 +34,7 @@ import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import ytdlpgui.composeapp.generated.resources.*
+import io.github.kdroidfilter.ytdlpgui.features.init.InitEvent
 import kotlin.time.Duration.Companion.seconds
 
 @Composable
@@ -36,6 +42,7 @@ fun FinishScreen(
     navController: NavHostController,
     viewModel: OnboardingViewModel = LocalAppGraph.current.onboardingViewModel,
 ) {
+    val appGraph = LocalAppGraph.current
     val currentStep by viewModel.currentStep.collectAsState()
     val initState by viewModel.initState.collectAsState()
     val state by viewModel.uiState.collectAsState()
@@ -59,7 +66,8 @@ fun FinishScreen(
         initState = initState,
         totalSteps = viewModel.getTotalSteps(),
         currentStepIndex = viewModel.getCurrentStepIndex(),
-        onComplete = { viewModel.completeOnboarding() }
+        onComplete = { viewModel.completeOnboarding() },
+        onRetryInit = { appGraph.initViewModel.handleEvent(InitEvent.StartInitialization) }
     )
 }
 
@@ -69,7 +77,8 @@ private fun FinishView(
     initState: InitState? = null,
     totalSteps: Int? = null,
     currentStepIndex: Int? = null,
-    onComplete: () -> Unit = {}
+    onComplete: () -> Unit = {},
+    onRetryInit: () -> Unit = {}
 ) {
     Column(
         Modifier.fillMaxSize().padding(16.dp),
@@ -86,29 +95,53 @@ private fun FinishView(
         if (initState?.initCompleted == true) {
             ReadyToGoScreen(onComplete = onComplete)
         } else {
-            LoadingResourcesScreen(initState = initState)
+            LoadingResourcesScreen(
+                initState = initState,
+                onRetryInit = onRetryInit,
+            )
         }
     }
 }
 
 @Composable
 private fun LoadingResourcesScreen(
-    initState: InitState? = null
+    initState: InitState? = null,
+    onRetryInit: () -> Unit = {},
 ) {
+    var showErrorDetails by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+
     Column(
         modifier = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(16.dp)
     ) {
-        Text(
-            text = stringResource(Res.string.onboarding_finish_loading_title),
-            style = FluentTheme.typography.subtitle
-        )
+        if (initState?.errorMessage != null) {
+            Text(
+                text = stringResource(Res.string.error_occurred),
+                style = FluentTheme.typography.subtitle,
+                color = FluentTheme.colors.system.critical,
+            )
+            Text(
+                text = initState.errorMessage,
+                style = FluentTheme.typography.bodyStrong,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = stringResource(Res.string.onboarding_finish_error_hint),
+                style = FluentTheme.typography.body,
+                textAlign = TextAlign.Center,
+            )
+        } else {
+            Text(
+                text = stringResource(Res.string.onboarding_finish_loading_title),
+                style = FluentTheme.typography.subtitle
+            )
 
-        Text(
-            text = stringResource(Res.string.onboarding_finish_loading_message),
-            style = FluentTheme.typography.bodyStrong
-        )
+            Text(
+                text = stringResource(Res.string.onboarding_finish_loading_message),
+                style = FluentTheme.typography.bodyStrong
+            )
+        }
 
         Spacer(Modifier.height(16.dp))
 
@@ -137,6 +170,30 @@ private fun LoadingResourcesScreen(
                 ProgressBar(modifier = Modifier.fillMaxWidth())
             }
         }
+
+        // Action when error occurs
+        if (initState?.errorMessage != null) {
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                AccentButton(onClick = onRetryInit) { Text(stringResource(Res.string.onboarding_finish_retry)) }
+                SubtleButton(onClick = { showErrorDetails = true }) {
+                    Text(stringResource(Res.string.view_error_details))
+                }
+            }
+        }
+    }
+
+    if (showErrorDetails && (initState?.errorMessage != null)) {
+        ContentDialog(
+            title = stringResource(Res.string.download_error_title),
+            visible = true,
+            size = DialogSize.Min,
+            primaryButtonText = stringResource(Res.string.ok),
+            onButtonClick = { showErrorDetails = false },
+            content = {
+                TerminalView(text = initState.errorMessage)
+            }
+        )
     }
 }
 


### PR DESCRIPTION
### Changes Made
- Display error details in `TerminalView` on Finish step of onboarding.
- Remove the "continue anyway" option in error scenarios.
- Allow retry after failure by resetting `isInitializing` on error/completion.
- Add French and Hebrew translations for newly introduced strings.

### Checklist
- [ ] Test coverage is added or updated.
- [ ] Relevant documentation is updated.
- [ ] Code adheres to contribution guidelines.