### PR TITLE
feat: add FFmpeg wrapper module

### DIFF
--- a/ffmpeg/README.md
+++ b/ffmpeg/README.md
@@ -1,0 +1,187 @@
+# FFmpeg Wrapper Module
+
+A Kotlin Multiplatform (JVM) wrapper for FFmpeg, providing an async, event-driven API for media conversion and analysis.
+
+## Features
+
+- **Automatic Binary Management**: Downloads and installs FFmpeg automatically
+- **Async Event-Driven API**: All operations use Kotlin Coroutines with event callbacks
+- **Media Analysis**: Extract detailed information from media files via FFprobe
+- **Video Encoding**: Support for H.264, H.265/HEVC, AV1, VP9
+- **Audio Encoding**: Support for AAC, MP3, Opus, FLAC, and more
+- **Progress Tracking**: Real-time progress updates during conversion
+- **Cancellation Support**: Cancel running conversions at any time
+
+## Quick Start
+
+```kotlin
+val ffmpeg = FfmpegWrapper()
+
+// Initialize (downloads FFmpeg if needed)
+ffmpeg.initialize { event ->
+    when (event) {
+        is InitEvent.DownloadingFfmpeg -> println("Downloading FFmpeg...")
+        is InitEvent.FfmpegProgress -> println("Progress: ${event.percent}%")
+        is InitEvent.Completed -> println("Ready!")
+        is InitEvent.Error -> println("Error: ${event.message}")
+        else -> {}
+    }
+}
+
+// Analyze a media file
+val info = ffmpeg.analyze(File("video.mkv")).getOrNull()
+println("Duration: ${info?.duration}")
+println("Video: ${info?.primaryVideo?.resolution}")
+println("Audio: ${info?.primaryAudio?.codec}")
+
+// Convert video
+val handle = ffmpeg.convert(
+    inputFile = File("input.mkv"),
+    outputFile = File("output.mp4"),
+    options = ConversionOptions.h264(crf = 23)
+) { event ->
+    when (event) {
+        is ConversionEvent.Started -> println("Started")
+        is ConversionEvent.Progress -> {
+            println("Time: ${event.timeProcessed}, Speed: ${event.speed}x")
+        }
+        is ConversionEvent.Completed -> println("Done: ${event.outputFile}")
+        is ConversionEvent.Error -> println("Error: ${event.message}")
+        is ConversionEvent.Cancelled -> println("Cancelled")
+        else -> {}
+    }
+}
+
+// Cancel if needed
+handle.cancel()
+```
+
+## Conversion Options
+
+### Video Encoding
+
+```kotlin
+// H.264 with CRF quality (recommended)
+ConversionOptions.h264(crf = 23, preset = EncoderPreset.MEDIUM)
+
+// H.265/HEVC with CRF quality
+ConversionOptions.h265(crf = 28, preset = EncoderPreset.SLOW)
+
+// AV1 encoding
+ConversionOptions.av1(crf = 35, preset = 6)
+
+// Stream copy (no re-encoding)
+ConversionOptions.copy()
+
+// Custom options
+ConversionOptions(
+    video = VideoOptions(
+        encoder = VideoEncoder.H264,
+        compressionType = CompressionType.CRF,
+        crf = 20,
+        preset = EncoderPreset.SLOWER,
+        resolution = Resolution.P1080,
+        pixelFormat = PixelFormat.BIT_10
+    ),
+    audio = AudioOptions(
+        encoder = AudioEncoder.AAC,
+        bitrate = AudioBitrate.K256
+    )
+)
+```
+
+### Audio Extraction
+
+```kotlin
+// Extract to MP3
+ConversionOptions.audioMp3(bitrate = AudioBitrate.K320)
+
+// Extract to AAC
+ConversionOptions.audioAac(bitrate = AudioBitrate.K256)
+
+// Quick methods
+ffmpeg.extractAudioMp3(inputFile, outputFile, AudioBitrate.K192) { event -> }
+ffmpeg.extractAudioAac(inputFile, outputFile, AudioBitrate.K256) { event -> }
+```
+
+### Trimming
+
+```kotlin
+ffmpeg.trim(
+    inputFile = inputFile,
+    outputFile = outputFile,
+    startTime = Duration.ofSeconds(30),
+    duration = Duration.ofMinutes(5),
+    copyStreams = true  // Fast, no re-encoding
+) { event -> }
+```
+
+## Video Encoders
+
+| Encoder | FFmpeg Name | CRF Range | Default CRF |
+|---------|-------------|-----------|-------------|
+| H.264   | libx264     | 0-51      | 23          |
+| H.265   | libx265     | 0-51      | 28          |
+| AV1     | libsvtav1   | 0-63      | 35          |
+| VP9     | libvpx-vp9  | 0-63      | 31          |
+
+## Audio Encoders
+
+| Encoder | FFmpeg Name   | Supports CBR | Supports VBR |
+|---------|---------------|--------------|--------------|
+| AAC     | aac           | Yes          | No           |
+| AAC FDK | libfdk_aac    | Yes          | Yes          |
+| MP3     | libmp3lame    | Yes          | Yes          |
+| Opus    | libopus       | Yes          | No           |
+| FLAC    | flac          | N/A (lossless) | N/A       |
+
+## Encoder Presets
+
+### H.264/H.265 Presets
+`ultrafast`, `superfast`, `veryfast`, `faster`, `fast`, `medium`, `slow`, `slower`, `veryslow`, `placebo`
+
+### SVT-AV1 Presets
+`0` (slowest/best) to `13` (fastest)
+
+## Media Analysis
+
+```kotlin
+val result = ffmpeg.analyze(File("video.mkv"))
+result.onSuccess { info ->
+    println("Format: ${info.format.formatName}")
+    println("Duration: ${info.duration}")
+    println("File size: ${info.fileSize}")
+
+    info.primaryVideo?.let { video ->
+        println("Video: ${video.codec} ${video.resolution} @ ${video.frameRate} fps")
+        println("Bit depth: ${video.bitDepth}")
+        println("HDR: ${video.isHdr}")
+    }
+
+    info.primaryAudio?.let { audio ->
+        println("Audio: ${audio.codec} ${audio.channels}ch @ ${audio.sampleRate} Hz")
+    }
+
+    info.subtitleStreams.forEach { sub ->
+        println("Subtitle: ${sub.language} (${sub.codec})")
+    }
+}
+```
+
+## Dependencies
+
+The module uses:
+- `kotlinx-coroutines` for async operations
+- `kotlinx-serialization` for JSON parsing (FFprobe output)
+- `platformtools` for GitHub release fetching
+- `filekit` for cross-platform app data directories
+
+## Platform Support
+
+- Windows (x64, x86, ARM64)
+- macOS (Intel, Apple Silicon)
+- Linux (x64, ARM64)
+
+FFmpeg binaries are downloaded from:
+- Windows/Linux: [yt-dlp/FFmpeg-Builds](https://github.com/yt-dlp/FFmpeg-Builds)
+- macOS: [eugeneware/ffmpeg-static](https://github.com/eugeneware/ffmpeg-static)

--- a/ffmpeg/build.gradle.kts
+++ b/ffmpeg/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+    alias(libs.plugins.kotlinMultiplatform)
+    alias(libs.plugins.kotlinSerialization)
+}
+
+kotlin {
+    jvm()
+
+    sourceSets {
+        jvmMain.dependencies {
+            // Network module (provides Ktor, SSL/TLS configuration)
+            implementation(project(":network"))
+            implementation(project(":logging"))
+
+            // Coroutines
+            implementation(libs.kotlinx.coroutinesSwing)
+
+            // Platform tools
+            implementation(libs.platformtools.releasefetcher)
+            implementation(libs.platformtools.core)
+
+            // FileKit for app data directory
+            implementation(libs.filekit.core)
+        }
+        jvmTest.dependencies {
+            implementation(libs.kotlin.test)
+            implementation(libs.kotlin.testJunit)
+        }
+    }
+}

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/FfmpegWrapper.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/FfmpegWrapper.kt
@@ -1,0 +1,571 @@
+package io.github.kdroidfilter.ffmpeg
+
+import io.github.kdroidfilter.ffmpeg.core.*
+import io.github.kdroidfilter.ffmpeg.model.*
+import io.github.kdroidfilter.ffmpeg.util.*
+import io.github.kdroidfilter.logging.debugln
+import io.github.kdroidfilter.logging.errorln
+import io.github.kdroidfilter.platformtools.releasefetcher.github.GitHubReleaseFetcher
+import kotlinx.coroutines.*
+import kotlinx.serialization.json.Json
+import java.io.BufferedReader
+import java.io.File
+import java.io.InputStreamReader
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Main entry point for FFmpeg operations.
+ *
+ * Provides async, event-driven API for:
+ * - Media conversion (video/audio transcoding)
+ * - Media analysis (via FFprobe)
+ * - Binary management (auto-download, updates)
+ *
+ * Example usage:
+ * ```kotlin
+ * val ffmpeg = FfmpegWrapper()
+ * ffmpeg.initialize { event ->
+ *     when (event) {
+ *         is InitEvent.Completed -> println("Ready!")
+ *         else -> {}
+ *     }
+ * }
+ *
+ * val handle = ffmpeg.convert(
+ *     inputFile = File("input.mkv"),
+ *     outputFile = File("output.mp4"),
+ *     options = ConversionOptions.h264(crf = 23)
+ * ) { event ->
+ *     when (event) {
+ *         is ConversionEvent.Progress -> println("Progress: ${event.timeProcessed}")
+ *         is ConversionEvent.Completed -> println("Done: ${event.outputFile}")
+ *         is ConversionEvent.Error -> println("Error: ${event.message}")
+ *         else -> {}
+ *     }
+ * }
+ * ```
+ */
+class FfmpegWrapper {
+
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    // --- Configurable Properties ---
+
+    /** Path to FFmpeg binary. Auto-detected if not set. */
+    @Volatile
+    var ffmpegPath: String = PlatformUtils.getDefaultFfmpegPath()
+
+    /** Path to FFprobe binary. Auto-detected if not set. */
+    @Volatile
+    var ffprobePath: String = PlatformUtils.getDefaultFfprobePath()
+
+    // --- Caches ---
+
+    @Volatile
+    private var cachedFfmpegVersion: String? = null
+
+    @Volatile
+    private var cachedFfprobeVersion: String? = null
+
+    private val mediaInfoCache = ConcurrentHashMap<String, MediaInfo>()
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        isLenient = true
+    }
+
+    // --- Initialization ---
+
+    /**
+     * Initialize FFmpeg, downloading if necessary.
+     * Emits [InitEvent]s to track progress.
+     */
+    fun initialize(onEvent: (InitEvent) -> Unit): Job = scope.launch {
+        try {
+            onEvent(InitEvent.CheckingFfmpeg)
+
+            // Check if FFmpeg is available
+            var ffmpegAvailable = isAvailable()
+
+            if (!ffmpegAvailable) {
+                // Try system PATH
+                val systemFfmpeg = PlatformUtils.findFfmpegInSystemPath()
+                if (systemFfmpeg != null) {
+                    ffmpegPath = systemFfmpeg
+                    val systemFfprobe = PlatformUtils.findFfprobeInSystemPath()
+                    if (systemFfprobe != null) {
+                        ffprobePath = systemFfprobe
+                    }
+                    ffmpegAvailable = true
+                }
+            }
+
+            if (!ffmpegAvailable) {
+                // Download FFmpeg
+                onEvent(InitEvent.DownloadingFfmpeg)
+
+                val assetPattern = PlatformUtils.getFfmpegAssetPatternForSystem()
+                    ?: error("Unsupported platform for FFmpeg download")
+
+                val ffmpegFetcher = GitHubReleaseFetcher("yt-dlp", "FFmpeg-Builds")
+
+                val installedPath = PlatformUtils.downloadAndInstallFfmpeg(
+                    assetPattern = assetPattern,
+                    forceDownload = false,
+                    ffmpegFetcher = ffmpegFetcher
+                ) { bytesRead, totalBytes ->
+                    val percent = totalBytes?.let { bytesRead.toDouble() / it * 100 }
+                    onEvent(InitEvent.FfmpegProgress(bytesRead, totalBytes, percent))
+                }
+
+                if (installedPath == null) {
+                    onEvent(InitEvent.Error("Failed to download FFmpeg"))
+                    return@launch
+                }
+
+                ffmpegPath = installedPath
+                ffprobePath = PlatformUtils.getDefaultFfprobePath()
+            }
+
+            cachedFfmpegVersion = null
+            cachedFfprobeVersion = null
+
+            onEvent(InitEvent.Completed(success = true))
+        } catch (e: Exception) {
+            errorln { "FFmpeg initialization failed: ${e.message}" }
+            onEvent(InitEvent.Error(e.message ?: "Unknown error", e))
+        }
+    }
+
+    /**
+     * Initialize in a specific coroutine scope.
+     */
+    fun initializeIn(externalScope: CoroutineScope, onEvent: (InitEvent) -> Unit): Job =
+        externalScope.launch { initialize(onEvent).join() }
+
+    // --- Availability & Version ---
+
+    /**
+     * Check if FFmpeg is available and runnable.
+     */
+    suspend fun isAvailable(): Boolean {
+        return PlatformUtils.getFfmpegVersion(ffmpegPath) != null
+    }
+
+    /**
+     * Check if FFprobe is available and runnable.
+     */
+    suspend fun isFfprobeAvailable(): Boolean {
+        return PlatformUtils.getFfprobeVersion(ffprobePath) != null
+    }
+
+    /**
+     * Get FFmpeg version string (cached).
+     */
+    suspend fun version(): String? {
+        cachedFfmpegVersion?.let { return it }
+        return PlatformUtils.getFfmpegVersion(ffmpegPath).also { cachedFfmpegVersion = it }
+    }
+
+    /**
+     * Get FFprobe version string (cached).
+     */
+    suspend fun ffprobeVersion(): String? {
+        cachedFfprobeVersion?.let { return it }
+        return PlatformUtils.getFfprobeVersion(ffprobePath).also { cachedFfprobeVersion = it }
+    }
+
+    // --- Media Analysis ---
+
+    /**
+     * Analyze a media file using FFprobe.
+     *
+     * @param file The media file to analyze.
+     * @param useCache Whether to use cached results if available.
+     * @return [MediaInfo] containing all stream and format information.
+     */
+    suspend fun analyze(file: File, useCache: Boolean = true): Result<MediaInfo> = withContext(Dispatchers.IO) {
+        val cacheKey = file.absolutePath
+
+        if (useCache) {
+            mediaInfoCache[cacheKey]?.let { return@withContext Result.success(it) }
+        }
+
+        try {
+            val cmd = CommandBuilder.buildProbeCommand(ffprobePath, file)
+            debugln { "FFprobe command: ${cmd.joinToString(" ")}" }
+
+            val process = ProcessBuilder(cmd)
+                .redirectErrorStream(false)
+                .start()
+
+            val output = process.inputStream.bufferedReader().readText()
+            val exitCode = process.waitFor()
+
+            if (exitCode != 0) {
+                val error = process.errorStream.bufferedReader().readText()
+                return@withContext Result.failure(Exception("FFprobe failed: $error"))
+            }
+
+            val response = json.decodeFromString<FfprobeResponse>(output)
+            val mediaInfo = parseMediaInfo(file, response)
+
+            if (useCache) {
+                mediaInfoCache[cacheKey] = mediaInfo
+            }
+
+            Result.success(mediaInfo)
+        } catch (e: Exception) {
+            errorln { "FFprobe analysis failed: ${e.message}" }
+            Result.failure(e)
+        }
+    }
+
+    /**
+     * Analyze a media file and emit events.
+     */
+    fun analyzeAsync(file: File, onEvent: (ProbeEvent) -> Unit): Job = scope.launch {
+        analyze(file).fold(
+            onSuccess = { onEvent(ProbeEvent.Completed(it)) },
+            onFailure = { onEvent(ProbeEvent.Error(it.message ?: "Analysis failed", it)) }
+        )
+    }
+
+    // --- Conversion ---
+
+    /**
+     * Convert a media file.
+     *
+     * @param inputFile Input media file.
+     * @param outputFile Output file path.
+     * @param options Conversion options.
+     * @param onEvent Callback for conversion events.
+     * @return [ConversionHandle] for cancellation.
+     */
+    fun convert(
+        inputFile: File,
+        outputFile: File,
+        options: ConversionOptions = ConversionOptions(),
+        onEvent: (ConversionEvent) -> Unit
+    ): ConversionHandle {
+        val job = scope.launch {
+            try {
+                // Validate input
+                if (!inputFile.exists()) {
+                    onEvent(ConversionEvent.Error("Input file does not exist: ${inputFile.absolutePath}"))
+                    return@launch
+                }
+
+                // Get input duration for progress calculation
+                val inputInfo = analyze(inputFile).getOrNull()
+                val totalDuration = inputInfo?.duration
+
+                // Build command
+                val cmd = CommandBuilder.build(ffmpegPath, inputFile, outputFile, options)
+                debugln { "FFmpeg command: ${cmd.joinToString(" ")}" }
+
+                // Prepare output directory
+                outputFile.parentFile?.mkdirs()
+
+                // Delete existing output if overwrite is enabled
+                if (options.overwrite && outputFile.exists()) {
+                    outputFile.delete()
+                }
+
+                onEvent(ConversionEvent.Started)
+
+                // Start process
+                val process = ProcessBuilder(cmd)
+                    .redirectErrorStream(true)
+                    .start()
+
+                // Store process for potential cancellation
+                val processRef = process
+
+                // Read output
+                val outputLines = mutableListOf<String>()
+                BufferedReader(InputStreamReader(process.inputStream)).use { reader ->
+                    reader.lineSequence().forEach { line ->
+                        if (!isActive) {
+                            processRef.destroyForcibly()
+                            return@forEach
+                        }
+
+                        outputLines.add(line)
+                        if (outputLines.size > 100) outputLines.removeAt(0)
+
+                        // Parse progress
+                        val progress = ProgressParser.parse(line)
+                        if (progress != null) {
+                            onEvent(ConversionEvent.Progress(
+                                timeProcessed = progress.time,
+                                speed = progress.speed,
+                                fps = progress.fps,
+                                bitrate = progress.bitrate,
+                                rawLine = line
+                            ))
+                        } else {
+                            onEvent(ConversionEvent.Log(line))
+                        }
+                    }
+                }
+
+                // Wait for completion with timeout
+                val exitCode = if (options.timeout != null) {
+                    withTimeoutOrNull(options.timeout.toMillis()) {
+                        withContext(Dispatchers.IO) { process.waitFor() }
+                    } ?: run {
+                        process.destroyForcibly()
+                        onEvent(ConversionEvent.Error("Conversion timed out"))
+                        return@launch
+                    }
+                } else {
+                    process.waitFor()
+                }
+
+                if (!isActive) {
+                    onEvent(ConversionEvent.Cancelled)
+                    return@launch
+                }
+
+                if (exitCode == 0 && outputFile.exists() && outputFile.length() > 0) {
+                    onEvent(ConversionEvent.Completed(outputFile, exitCode))
+                } else {
+                    val diagnosis = ErrorDiagnostics.diagnose(outputLines)
+                    onEvent(ConversionEvent.Error(diagnosis ?: "Conversion failed with exit code $exitCode"))
+                }
+
+            } catch (e: CancellationException) {
+                onEvent(ConversionEvent.Cancelled)
+            } catch (e: Exception) {
+                errorln { "Conversion error: ${e.message}" }
+                onEvent(ConversionEvent.Error(e.message ?: "Unknown error", e))
+            }
+        }
+
+        return ConversionHandle(job)
+    }
+
+    // --- Quick Conversion Methods ---
+
+    /**
+     * Extract audio to MP3.
+     */
+    fun extractAudioMp3(
+        inputFile: File,
+        outputFile: File,
+        bitrate: AudioBitrate = AudioBitrate.K192,
+        onEvent: (ConversionEvent) -> Unit
+    ): ConversionHandle = convert(
+        inputFile = inputFile,
+        outputFile = outputFile,
+        options = ConversionOptions.audioMp3(bitrate),
+        onEvent = onEvent
+    )
+
+    /**
+     * Extract audio to AAC/M4A.
+     */
+    fun extractAudioAac(
+        inputFile: File,
+        outputFile: File,
+        bitrate: AudioBitrate = AudioBitrate.K192,
+        onEvent: (ConversionEvent) -> Unit
+    ): ConversionHandle = convert(
+        inputFile = inputFile,
+        outputFile = outputFile,
+        options = ConversionOptions.audioAac(bitrate),
+        onEvent = onEvent
+    )
+
+    /**
+     * Copy streams without re-encoding (remux).
+     */
+    fun remux(
+        inputFile: File,
+        outputFile: File,
+        onEvent: (ConversionEvent) -> Unit
+    ): ConversionHandle = convert(
+        inputFile = inputFile,
+        outputFile = outputFile,
+        options = ConversionOptions.copy(),
+        onEvent = onEvent
+    )
+
+    /**
+     * Encode video with H.264 codec.
+     */
+    fun encodeH264(
+        inputFile: File,
+        outputFile: File,
+        crf: Int = 23,
+        preset: EncoderPreset = EncoderPreset.MEDIUM,
+        onEvent: (ConversionEvent) -> Unit
+    ): ConversionHandle = convert(
+        inputFile = inputFile,
+        outputFile = outputFile,
+        options = ConversionOptions.h264(crf, preset),
+        onEvent = onEvent
+    )
+
+    /**
+     * Encode video with H.265/HEVC codec.
+     */
+    fun encodeH265(
+        inputFile: File,
+        outputFile: File,
+        crf: Int = 28,
+        preset: EncoderPreset = EncoderPreset.MEDIUM,
+        onEvent: (ConversionEvent) -> Unit
+    ): ConversionHandle = convert(
+        inputFile = inputFile,
+        outputFile = outputFile,
+        options = ConversionOptions.h265(crf, preset),
+        onEvent = onEvent
+    )
+
+    /**
+     * Trim a video/audio file.
+     */
+    fun trim(
+        inputFile: File,
+        outputFile: File,
+        startTime: Duration,
+        duration: Duration? = null,
+        endTime: Duration? = null,
+        copyStreams: Boolean = true,
+        onEvent: (ConversionEvent) -> Unit
+    ): ConversionHandle = convert(
+        inputFile = inputFile,
+        outputFile = outputFile,
+        options = ConversionOptions(
+            video = if (copyStreams) VideoOptions(compressionType = CompressionType.COPY) else VideoOptions(),
+            audio = if (copyStreams) AudioOptions(compressionType = AudioCompressionType.COPY) else AudioOptions(),
+            startTime = startTime,
+            duration = duration,
+            endTime = endTime
+        ),
+        onEvent = onEvent
+    )
+
+    // --- Cache Management ---
+
+    /**
+     * Clear the media info cache.
+     */
+    fun clearCache() {
+        mediaInfoCache.clear()
+        cachedFfmpegVersion = null
+        cachedFfprobeVersion = null
+    }
+
+    /**
+     * Remove a specific file from the cache.
+     */
+    fun invalidateCache(file: File) {
+        mediaInfoCache.remove(file.absolutePath)
+    }
+
+    // --- Cleanup ---
+
+    /**
+     * Cancel all running operations and clean up resources.
+     */
+    fun shutdown() {
+        scope.cancel()
+        clearCache()
+    }
+
+    // --- Private Helpers ---
+
+    private fun parseMediaInfo(file: File, response: FfprobeResponse): MediaInfo {
+        val format = response.format?.let { fmt ->
+            FormatInfo(
+                formatName = fmt.formatName,
+                formatLongName = fmt.formatLongName,
+                duration = fmt.duration?.toDoubleOrNull()?.let { Duration.ofMillis((it * 1000).toLong()) },
+                bitRate = fmt.bitRate?.toLongOrNull(),
+                streamCount = fmt.nbStreams ?: response.streams.size
+            )
+        } ?: FormatInfo(null, null, null, null, 0)
+
+        val videoStreams = response.streams
+            .filter { it.codecType == "video" }
+            .map { stream ->
+                VideoStreamInfo(
+                    index = stream.index,
+                    codec = stream.codecName,
+                    codecLongName = stream.codecLongName,
+                    profile = stream.profile,
+                    width = stream.width,
+                    height = stream.height,
+                    frameRate = parseFrameRate(stream.rFrameRate ?: stream.avgFrameRate),
+                    bitRate = stream.bitRate?.toLongOrNull(),
+                    pixelFormat = stream.pixFmt,
+                    bitDepth = stream.bitsPerRawSample?.toIntOrNull()
+                        ?: stream.pixFmt?.let { if (it.contains("10")) 10 else 8 },
+                    level = stream.level,
+                    fieldOrder = stream.fieldOrder,
+                    aspectRatio = stream.displayAspectRatio,
+                    hasFilmGrain = (stream.filmGrain ?: 0) > 0,
+                    title = stream.tags?.title,
+                    language = stream.tags?.language
+                )
+            }
+
+        val audioStreams = response.streams
+            .filter { it.codecType == "audio" }
+            .map { stream ->
+                AudioStreamInfo(
+                    index = stream.index,
+                    codec = stream.codecName,
+                    codecLongName = stream.codecLongName,
+                    profile = stream.profile,
+                    sampleRate = stream.sampleRate?.toIntOrNull(),
+                    channels = stream.channels,
+                    channelLayout = stream.channelLayout,
+                    bitRate = stream.bitRate?.toLongOrNull(),
+                    bitDepth = stream.bitsPerSample,
+                    title = stream.tags?.title,
+                    language = stream.tags?.language
+                )
+            }
+
+        val subtitleStreams = response.streams
+            .filter { it.codecType == "subtitle" }
+            .map { stream ->
+                SubtitleStreamInfo(
+                    index = stream.index,
+                    codec = stream.codecName,
+                    codecLongName = stream.codecLongName,
+                    title = stream.tags?.title,
+                    language = stream.tags?.language
+                )
+            }
+
+        return MediaInfo(
+            file = file,
+            format = format,
+            videoStreams = videoStreams,
+            audioStreams = audioStreams,
+            subtitleStreams = subtitleStreams
+        )
+    }
+
+    private fun parseFrameRate(frameRate: String?): Double? {
+        if (frameRate == null) return null
+        return try {
+            if (frameRate.contains("/")) {
+                val parts = frameRate.split("/")
+                val num = parts[0].toDoubleOrNull() ?: return null
+                val den = parts[1].toDoubleOrNull() ?: return null
+                if (den == 0.0) null else num / den
+            } else {
+                frameRate.toDoubleOrNull()
+            }
+        } catch (_: Exception) {
+            null
+        }
+    }
+}

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/core/Events.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/core/Events.kt
@@ -1,0 +1,71 @@
+package io.github.kdroidfilter.ffmpeg.core
+
+import kotlinx.coroutines.Job
+import java.io.File
+import java.time.Duration
+
+/**
+ * Represents the various events that can be emitted during an FFmpeg conversion process.
+ */
+sealed class ConversionEvent {
+    /** Indicates conversion progress. */
+    data class Progress(
+        val timeProcessed: Duration,
+        val speed: Double?,
+        val fps: Double?,
+        val bitrate: Long?,
+        val rawLine: String
+    ) : ConversionEvent()
+
+    /** A generic log message from the FFmpeg process. */
+    data class Log(val line: String) : ConversionEvent()
+
+    /** An error occurred during the process. */
+    data class Error(val message: String, val cause: Throwable? = null) : ConversionEvent()
+
+    /** The process has finished successfully. */
+    data class Completed(val outputFile: File, val exitCode: Int) : ConversionEvent()
+
+    /** The process was cancelled by the user. */
+    data object Cancelled : ConversionEvent()
+
+    /** The process has started. */
+    data object Started : ConversionEvent()
+}
+
+/**
+ * Events emitted during FFprobe media analysis.
+ */
+sealed class ProbeEvent {
+    /** Analysis completed successfully. */
+    data class Completed(val info: io.github.kdroidfilter.ffmpeg.model.MediaInfo) : ProbeEvent()
+
+    /** An error occurred during analysis. */
+    data class Error(val message: String, val cause: Throwable? = null) : ProbeEvent()
+}
+
+/**
+ * Events emitted during FFmpeg initialization.
+ */
+sealed interface InitEvent {
+    data object CheckingFfmpeg : InitEvent
+    data object DownloadingFfmpeg : InitEvent
+    data class FfmpegProgress(val bytesRead: Long, val totalBytes: Long?, val percent: Double?) : InitEvent
+    data class Completed(val success: Boolean) : InitEvent
+    data class Error(val message: String, val cause: Throwable? = null) : InitEvent
+}
+
+/**
+ * A handle to a running FFmpeg process, allowing for cancellation.
+ * @property job The underlying coroutine [Job] controlling the conversion lifecycle.
+ */
+data class ConversionHandle(
+    val job: Job
+) {
+    /**
+     * Cancels the running FFmpeg process by cancelling its coroutine job.
+     */
+    fun cancel() {
+        job.cancel()
+    }
+}

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/core/Options.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/core/Options.kt
@@ -1,0 +1,165 @@
+package io.github.kdroidfilter.ffmpeg.core
+
+import io.github.kdroidfilter.ffmpeg.model.*
+import java.time.Duration
+
+/**
+ * Configuration options for video encoding.
+ */
+data class VideoOptions(
+    val encoder: VideoEncoder = VideoEncoder.H264,
+    val compressionType: CompressionType = CompressionType.CRF,
+    val crf: Int? = null,
+    val bitrate: VideoBitrate? = null,
+    val preset: EncoderPreset? = null,
+    val resolution: Resolution? = null,
+    val pixelFormat: PixelFormat? = null,
+    val frameRate: Double? = null,
+    val profile: String? = null,
+    val filters: List<String> = emptyList()
+)
+
+/**
+ * Configuration options for audio encoding.
+ */
+data class AudioOptions(
+    val encoder: AudioEncoder = AudioEncoder.AAC,
+    val compressionType: AudioCompressionType = AudioCompressionType.CBR,
+    val bitrate: AudioBitrate? = null,
+    val vbr: Int? = null,
+    val sampleRate: SampleRate? = null,
+    val channels: Channels? = null,
+    val filters: List<String> = emptyList()
+)
+
+/**
+ * Configuration options for subtitle handling.
+ */
+data class SubtitleOptions(
+    val copy: Boolean = true,
+    val encoder: String? = null
+)
+
+/**
+ * Stream selection configuration.
+ * - `null` = use first available stream
+ * - `-1` = exclude stream
+ * - `0+` = use specific stream index
+ */
+data class StreamSelection(
+    val videoStream: Int? = null,
+    val audioStream: Int? = null,
+    val subtitleStream: Int? = -1
+)
+
+/**
+ * Main configuration options for an FFmpeg conversion.
+ *
+ * @property video Video encoding options. Null to exclude video.
+ * @property audio Audio encoding options. Null to exclude audio.
+ * @property subtitle Subtitle handling options. Null to exclude subtitles.
+ * @property streamSelection Which streams to select from the input.
+ * @property outputFormat Force output format (e.g., "mp4", "mkv", "mp3").
+ * @property startTime Start time for trimming. Null for no trim.
+ * @property duration Duration to encode. Null for full length.
+ * @property endTime End time for trimming. Null for no trim.
+ * @property overwrite Overwrite output file if it exists.
+ * @property metadata Metadata to set on output file.
+ * @property mapMetadata Map metadata from input (-1 to disable).
+ * @property mapChapters Map chapters from input (-1 to disable).
+ * @property extraArgs Additional FFmpeg arguments.
+ * @property timeout Maximum duration for the conversion. Null for no timeout.
+ * @property logLevel FFmpeg log level.
+ * @property twoPass Enable two-pass encoding for better quality at target bitrate.
+ * @property hwAccel Hardware acceleration (e.g., "cuda", "vaapi", "videotoolbox").
+ */
+data class ConversionOptions(
+    val video: VideoOptions? = VideoOptions(),
+    val audio: AudioOptions? = AudioOptions(),
+    val subtitle: SubtitleOptions? = null,
+    val streamSelection: StreamSelection = StreamSelection(),
+    val outputFormat: String? = null,
+    val startTime: Duration? = null,
+    val duration: Duration? = null,
+    val endTime: Duration? = null,
+    val overwrite: Boolean = true,
+    val metadata: Map<String, String> = emptyMap(),
+    val mapMetadata: Int? = 0,
+    val mapChapters: Int? = 0,
+    val extraArgs: List<String> = emptyList(),
+    val timeout: Duration? = Duration.ofHours(4),
+    val logLevel: LogLevel = LogLevel.INFO,
+    val twoPass: Boolean = false,
+    val hwAccel: String? = null
+) {
+    companion object {
+        /** Quick audio extraction to MP3. */
+        fun audioMp3(bitrate: AudioBitrate = AudioBitrate.K192) = ConversionOptions(
+            video = null,
+            audio = AudioOptions(
+                encoder = AudioEncoder.MP3,
+                bitrate = bitrate
+            )
+        )
+
+        /** Quick audio extraction to AAC. */
+        fun audioAac(bitrate: AudioBitrate = AudioBitrate.K192) = ConversionOptions(
+            video = null,
+            audio = AudioOptions(
+                encoder = AudioEncoder.AAC,
+                bitrate = bitrate
+            )
+        )
+
+        /** Quick video copy (no re-encoding). */
+        fun copy() = ConversionOptions(
+            video = VideoOptions(compressionType = CompressionType.COPY),
+            audio = AudioOptions(compressionType = AudioCompressionType.COPY)
+        )
+
+        /** H.264 encoding with CRF quality. */
+        fun h264(crf: Int = 23, preset: EncoderPreset = EncoderPreset.MEDIUM) = ConversionOptions(
+            video = VideoOptions(
+                encoder = VideoEncoder.H264,
+                compressionType = CompressionType.CRF,
+                crf = crf,
+                preset = preset
+            )
+        )
+
+        /** H.265/HEVC encoding with CRF quality. */
+        fun h265(crf: Int = 28, preset: EncoderPreset = EncoderPreset.MEDIUM) = ConversionOptions(
+            video = VideoOptions(
+                encoder = VideoEncoder.H265,
+                compressionType = CompressionType.CRF,
+                crf = crf,
+                preset = preset
+            )
+        )
+
+        /** AV1 encoding with CRF quality. */
+        fun av1(crf: Int = 35, preset: Int = 6) = ConversionOptions(
+            video = VideoOptions(
+                encoder = VideoEncoder.AV1,
+                compressionType = CompressionType.CRF,
+                crf = crf,
+                preset = EncoderPreset.fromSvtAv1Preset(preset)
+            )
+        )
+    }
+}
+
+/**
+ * FFmpeg log level.
+ */
+enum class LogLevel(val value: String) {
+    QUIET("quiet"),
+    PANIC("panic"),
+    FATAL("fatal"),
+    ERROR("error"),
+    WARNING("warning"),
+    INFO("info"),
+    VERBOSE("verbose"),
+    DEBUG("debug"),
+    TRACE("trace")
+}

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/demos/analyze.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/demos/analyze.kt
@@ -1,0 +1,96 @@
+package io.github.kdroidfilter.ffmpeg.demos
+
+import io.github.kdroidfilter.ffmpeg.FfmpegWrapper
+import io.github.kdroidfilter.ffmpeg.core.InitEvent
+import io.github.kdroidfilter.logging.LoggerConfig
+import io.github.kdroidfilter.logging.infoln
+import io.github.kdroidfilter.logging.warnln
+import io.github.kdroidfilter.logging.errorln
+import kotlinx.coroutines.runBlocking
+import java.io.File
+
+/**
+ * Demo: Analyze a media file and print its information.
+ *
+ * Usage: Set the `inputPath` variable to a media file path and run.
+ */
+fun main() = runBlocking {
+    LoggerConfig.enabled = true
+
+    val inputPath = "/path/to/your/video.mp4"
+    val inputFile = File(inputPath)
+
+    if (!inputFile.exists()) {
+        errorln { "File not found: $inputPath" }
+        return@runBlocking
+    }
+
+    val ffmpeg = FfmpegWrapper()
+
+    // Initialize FFmpeg
+    infoln { "Initializing FFmpeg..." }
+    ffmpeg.initialize { event ->
+        when (event) {
+            is InitEvent.CheckingFfmpeg -> infoln { "Checking FFmpeg..." }
+            is InitEvent.DownloadingFfmpeg -> infoln { "Downloading FFmpeg..." }
+            is InitEvent.FfmpegProgress -> {
+                val percent = event.percent?.let { "%.1f%%".format(it) } ?: "..."
+                infoln { "Download progress: $percent" }
+            }
+            is InitEvent.Completed -> infoln { "FFmpeg ready!" }
+            is InitEvent.Error -> errorln { "Error: ${event.message}" }
+        }
+    }.join()
+
+    // Analyze the file
+    infoln { "Analyzing: ${inputFile.name}" }
+    infoln { "=" .repeat(50) }
+
+    val result = ffmpeg.analyze(inputFile)
+
+    result.fold(
+        onSuccess = { info ->
+            infoln { "Format: ${info.format.formatLongName ?: info.format.formatName}" }
+            infoln { "Duration: ${info.duration}" }
+            infoln { "Bitrate: ${info.format.bitRate?.let { "${it / 1000} kbps" } ?: "N/A"}" }
+            infoln { "File size: ${info.fileSize / 1024 / 1024} MB" }
+            infoln { "" }
+
+            if (info.videoStreams.isNotEmpty()) {
+                infoln { "Video Streams:" }
+                info.videoStreams.forEachIndexed { index, video ->
+                    infoln { "  [$index] ${video.codec} ${video.resolution}" }
+                    infoln { "       Frame rate: ${video.frameRate?.let { "%.2f fps".format(it) } ?: "N/A"}" }
+                    infoln { "       Bit depth: ${video.bitDepth ?: 8}-bit" }
+                    infoln { "       Pixel format: ${video.pixelFormat}" }
+                    infoln { "       HDR: ${video.isHdr}" }
+                    video.language?.let { infoln { "       Language: $it" } }
+                }
+                infoln { "" }
+            }
+
+            if (info.audioStreams.isNotEmpty()) {
+                infoln { "Audio Streams:" }
+                info.audioStreams.forEachIndexed { index, audio ->
+                    infoln { "  [$index] ${audio.codec} ${audio.channels}ch @ ${audio.sampleRate} Hz" }
+                    audio.bitRate?.let { infoln { "       Bitrate: ${it / 1000} kbps" } }
+                    audio.language?.let { infoln { "       Language: $it" } }
+                }
+                infoln { "" }
+            }
+
+            if (info.subtitleStreams.isNotEmpty()) {
+                infoln { "Subtitle Streams:" }
+                info.subtitleStreams.forEachIndexed { index, sub ->
+                    infoln { "  [$index] ${sub.codec} - ${sub.language ?: "Unknown"}" }
+                    sub.title?.let { infoln { "       Title: $it" } }
+                }
+            }
+        },
+        onFailure = { error ->
+            errorln { "Analysis failed: ${error.message}" }
+        }
+    )
+
+    ffmpeg.shutdown()
+}

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/demos/convert.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/demos/convert.kt
@@ -1,0 +1,104 @@
+package io.github.kdroidfilter.ffmpeg.demos
+
+import io.github.kdroidfilter.ffmpeg.FfmpegWrapper
+import io.github.kdroidfilter.ffmpeg.core.ConversionEvent
+import io.github.kdroidfilter.ffmpeg.core.ConversionOptions
+import io.github.kdroidfilter.ffmpeg.core.InitEvent
+import io.github.kdroidfilter.ffmpeg.model.EncoderPreset
+import io.github.kdroidfilter.logging.LoggerConfig
+import io.github.kdroidfilter.logging.infoln
+import io.github.kdroidfilter.logging.errorln
+import io.github.kdroidfilter.logging.debugln
+import kotlinx.coroutines.runBlocking
+import java.io.File
+
+/**
+ * Demo: Convert a video file to H.264 MP4.
+ *
+ * Usage: Set the `inputPath` variable to your input file and run.
+ */
+fun main() = runBlocking {
+    LoggerConfig.enabled = true
+
+    val inputPath = "/path/to/your/input.mkv"
+    val outputPath = "/path/to/your/output.mp4"
+
+    val inputFile = File(inputPath)
+    val outputFile = File(outputPath)
+
+    if (!inputFile.exists()) {
+        errorln { "Input file not found: $inputPath" }
+        return@runBlocking
+    }
+
+    val ffmpeg = FfmpegWrapper()
+
+    // Initialize
+    infoln { "Initializing FFmpeg..." }
+    ffmpeg.initialize { event ->
+        when (event) {
+            is InitEvent.Completed -> infoln { "FFmpeg ready!" }
+            is InitEvent.Error -> {
+                errorln { "Init error: ${event.message}" }
+                return@initialize
+            }
+            else -> {}
+        }
+    }.join()
+
+    // Get input duration for progress calculation
+    val inputInfo = ffmpeg.analyze(inputFile).getOrNull()
+    val totalDuration = inputInfo?.duration
+
+    infoln { "Converting: ${inputFile.name}" }
+    infoln { "Output: ${outputFile.name}" }
+    infoln { "Duration: $totalDuration" }
+    infoln { "=" .repeat(50) }
+
+    // Convert with H.264
+    val handle = ffmpeg.convert(
+        inputFile = inputFile,
+        outputFile = outputFile,
+        options = ConversionOptions.h264(crf = 23, preset = EncoderPreset.MEDIUM)
+    ) { event ->
+        when (event) {
+            is ConversionEvent.Started -> infoln { "Conversion started..." }
+
+            is ConversionEvent.Progress -> {
+                val percent = totalDuration?.let {
+                    val p = event.timeProcessed.toMillis().toDouble() / it.toMillis() * 100
+                    "%.1f%%".format(p.coerceIn(0.0, 100.0))
+                } ?: event.timeProcessed.toString()
+
+                val speed = event.speed?.let { "%.2fx".format(it) } ?: "N/A"
+                val fps = event.fps?.let { "%.1f fps".format(it) } ?: ""
+
+                infoln { "Progress: $percent | Speed: $speed $fps" }
+            }
+
+            is ConversionEvent.Log -> {
+                debugln { event.line }
+            }
+
+            is ConversionEvent.Completed -> {
+                infoln { "=" .repeat(50) }
+                infoln { "Conversion completed!" }
+                infoln { "Output: ${event.outputFile.absolutePath}" }
+                infoln { "Size: ${event.outputFile.length() / 1024 / 1024} MB" }
+            }
+
+            is ConversionEvent.Error -> {
+                errorln { "Error: ${event.message}" }
+            }
+
+            is ConversionEvent.Cancelled -> {
+                infoln { "Conversion cancelled" }
+            }
+        }
+    }
+
+    // Wait for completion
+    handle.job.join()
+
+    ffmpeg.shutdown()
+}

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/demos/extractAudio.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/demos/extractAudio.kt
@@ -1,0 +1,94 @@
+package io.github.kdroidfilter.ffmpeg.demos
+
+import io.github.kdroidfilter.ffmpeg.FfmpegWrapper
+import io.github.kdroidfilter.ffmpeg.core.ConversionEvent
+import io.github.kdroidfilter.ffmpeg.core.InitEvent
+import io.github.kdroidfilter.ffmpeg.model.AudioBitrate
+import io.github.kdroidfilter.logging.LoggerConfig
+import io.github.kdroidfilter.logging.infoln
+import io.github.kdroidfilter.logging.errorln
+import kotlinx.coroutines.runBlocking
+import java.io.File
+
+/**
+ * Demo: Extract audio from a video file to MP3.
+ *
+ * Usage: Set the `inputPath` variable to your input file and run.
+ */
+fun main() = runBlocking {
+    LoggerConfig.enabled = true
+
+    val inputPath = "/path/to/your/video.mp4"
+    val outputPath = "/path/to/your/audio.mp3"
+
+    val inputFile = File(inputPath)
+    val outputFile = File(outputPath)
+
+    if (!inputFile.exists()) {
+        errorln { "Input file not found: $inputPath" }
+        return@runBlocking
+    }
+
+    val ffmpeg = FfmpegWrapper()
+
+    // Initialize
+    infoln { "Initializing FFmpeg..." }
+    ffmpeg.initialize { event ->
+        when (event) {
+            is InitEvent.Completed -> infoln { "FFmpeg ready!" }
+            is InitEvent.Error -> {
+                errorln { "Init error: ${event.message}" }
+                return@initialize
+            }
+            else -> {}
+        }
+    }.join()
+
+    // Get input info
+    val inputInfo = ffmpeg.analyze(inputFile).getOrNull()
+    val totalDuration = inputInfo?.duration
+
+    infoln { "Extracting audio from: ${inputFile.name}" }
+    infoln { "Output: ${outputFile.name}" }
+    inputInfo?.primaryAudio?.let { audio ->
+        infoln { "Source audio: ${audio.codec} ${audio.channels}ch @ ${audio.sampleRate} Hz" }
+    }
+    infoln { "=" .repeat(50) }
+
+    // Extract audio to MP3 at 320 kbps
+    val handle = ffmpeg.extractAudioMp3(
+        inputFile = inputFile,
+        outputFile = outputFile,
+        bitrate = AudioBitrate.K320
+    ) { event ->
+        when (event) {
+            is ConversionEvent.Started -> infoln { "Extraction started..." }
+
+            is ConversionEvent.Progress -> {
+                val percent = totalDuration?.let {
+                    val p = event.timeProcessed.toMillis().toDouble() / it.toMillis() * 100
+                    "%.1f%%".format(p.coerceIn(0.0, 100.0))
+                } ?: event.timeProcessed.toString()
+
+                val speed = event.speed?.let { "%.2fx".format(it) } ?: "N/A"
+                infoln { "Progress: $percent | Speed: $speed" }
+            }
+
+            is ConversionEvent.Completed -> {
+                infoln { "=" .repeat(50) }
+                infoln { "Audio extraction completed!" }
+                infoln { "Output: ${event.outputFile.absolutePath}" }
+                infoln { "Size: ${event.outputFile.length() / 1024} KB" }
+            }
+
+            is ConversionEvent.Error -> {
+                errorln { "Error: ${event.message}" }
+            }
+
+            else -> {}
+        }
+    }
+
+    handle.job.join()
+    ffmpeg.shutdown()
+}

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/model/Bitrate.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/model/Bitrate.kt
@@ -1,0 +1,58 @@
+package io.github.kdroidfilter.ffmpeg.model
+
+/**
+ * Video bitrate presets.
+ */
+enum class VideoBitrate(val bitsPerSecond: Long, val displayName: String) {
+    M1(1_000_000, "1 Mbps"),
+    M2(2_000_000, "2 Mbps"),
+    M3(3_000_000, "3 Mbps"),
+    M4(4_000_000, "4 Mbps"),
+    M5(5_000_000, "5 Mbps"),
+    M6(6_000_000, "6 Mbps"),
+    M8(8_000_000, "8 Mbps"),
+    M10(10_000_000, "10 Mbps"),
+    M12(12_000_000, "12 Mbps"),
+    M15(15_000_000, "15 Mbps"),
+    M20(20_000_000, "20 Mbps"),
+    M25(25_000_000, "25 Mbps"),
+    M30(30_000_000, "30 Mbps"),
+    M40(40_000_000, "40 Mbps"),
+    M50(50_000_000, "50 Mbps");
+
+    val ffmpegValue: String get() = "${bitsPerSecond / 1_000_000}M"
+
+    companion object {
+        fun fromBitsPerSecond(bps: Long): VideoBitrate? =
+            entries.minByOrNull { kotlin.math.abs(it.bitsPerSecond - bps) }
+    }
+}
+
+/**
+ * Audio bitrate presets.
+ */
+enum class AudioBitrate(val bitsPerSecond: Long, val displayName: String) {
+    K32(32_000, "32 kbps"),
+    K48(48_000, "48 kbps"),
+    K64(64_000, "64 kbps"),
+    K80(80_000, "80 kbps"),
+    K96(96_000, "96 kbps"),
+    K112(112_000, "112 kbps"),
+    K128(128_000, "128 kbps"),
+    K160(160_000, "160 kbps"),
+    K192(192_000, "192 kbps"),
+    K224(224_000, "224 kbps"),
+    K256(256_000, "256 kbps"),
+    K288(288_000, "288 kbps"),
+    K320(320_000, "320 kbps"),
+    K384(384_000, "384 kbps"),
+    K448(448_000, "448 kbps"),
+    K512(512_000, "512 kbps");
+
+    val ffmpegValue: String get() = "${bitsPerSecond / 1_000}k"
+
+    companion object {
+        fun fromBitsPerSecond(bps: Long): AudioBitrate? =
+            entries.minByOrNull { kotlin.math.abs(it.bitsPerSecond - bps) }
+    }
+}

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/model/Encoder.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/model/Encoder.kt
@@ -1,0 +1,238 @@
+package io.github.kdroidfilter.ffmpeg.model
+
+/**
+ * Compression type for video encoding.
+ */
+enum class CompressionType {
+    /** Direct stream copy - no re-encoding. */
+    COPY,
+    /** Constant Bitrate - fixed bitrate throughout. */
+    CBR,
+    /** Constant Rate Factor - quality-based encoding (recommended). */
+    CRF
+}
+
+/**
+ * Compression type for audio encoding.
+ */
+enum class AudioCompressionType {
+    /** Direct stream copy - no re-encoding. */
+    COPY,
+    /** Constant Bitrate - fixed bitrate throughout. */
+    CBR,
+    /** Variable Bitrate - quality-based encoding. */
+    VBR
+}
+
+/**
+ * Video encoders supported by FFmpeg.
+ */
+enum class VideoEncoder(
+    val ffmpegName: String,
+    val displayName: String,
+    val defaultCrf: Int,
+    val minCrf: Int,
+    val maxCrf: Int,
+    val defaultPreset: EncoderPreset,
+    val supportsPreset: Boolean = true
+) {
+    H264(
+        ffmpegName = "libx264",
+        displayName = "H.264 (x264)",
+        defaultCrf = 23,
+        minCrf = 0,
+        maxCrf = 51,
+        defaultPreset = EncoderPreset.MEDIUM
+    ),
+    H265(
+        ffmpegName = "libx265",
+        displayName = "H.265/HEVC (x265)",
+        defaultCrf = 28,
+        minCrf = 0,
+        maxCrf = 51,
+        defaultPreset = EncoderPreset.MEDIUM
+    ),
+    AV1(
+        ffmpegName = "libsvtav1",
+        displayName = "AV1 (SVT-AV1)",
+        defaultCrf = 35,
+        minCrf = 0,
+        maxCrf = 63,
+        defaultPreset = EncoderPreset.PRESET_6
+    ),
+    VP9(
+        ffmpegName = "libvpx-vp9",
+        displayName = "VP9",
+        defaultCrf = 31,
+        minCrf = 0,
+        maxCrf = 63,
+        defaultPreset = EncoderPreset.GOOD,
+        supportsPreset = false
+    ),
+    MPEG4(
+        ffmpegName = "mpeg4",
+        displayName = "MPEG-4",
+        defaultCrf = 4,
+        minCrf = 1,
+        maxCrf = 31,
+        defaultPreset = EncoderPreset.MEDIUM,
+        supportsPreset = false
+    );
+
+    /**
+     * Get the appropriate video profile for this encoder based on pixel format.
+     */
+    fun getProfile(pixelFormat: PixelFormat?): String? = when (this) {
+        H264 -> if (pixelFormat == PixelFormat.BIT_10) "high10" else "high"
+        H265 -> if (pixelFormat == PixelFormat.BIT_10) "main10" else "main"
+        AV1 -> "0"
+        else -> null
+    }
+}
+
+/**
+ * Audio encoders supported by FFmpeg.
+ */
+enum class AudioEncoder(
+    val ffmpegName: String,
+    val displayName: String,
+    val supportsCbr: Boolean = true,
+    val supportsVbr: Boolean = false,
+    val defaultVbr: Int? = null,
+    val minVbr: Int? = null,
+    val maxVbr: Int? = null
+) {
+    AAC(
+        ffmpegName = "aac",
+        displayName = "AAC (Native)"
+    ),
+    AAC_FDK(
+        ffmpegName = "libfdk_aac",
+        displayName = "AAC (FDK)",
+        supportsVbr = true,
+        defaultVbr = 4,
+        minVbr = 1,
+        maxVbr = 5
+    ),
+    MP3(
+        ffmpegName = "libmp3lame",
+        displayName = "MP3 (LAME)",
+        supportsVbr = true,
+        defaultVbr = 2,
+        minVbr = 0,
+        maxVbr = 9
+    ),
+    OPUS(
+        ffmpegName = "libopus",
+        displayName = "Opus"
+    ),
+    VORBIS(
+        ffmpegName = "libvorbis",
+        displayName = "Vorbis",
+        supportsVbr = true,
+        defaultVbr = 5,
+        minVbr = 0,
+        maxVbr = 10
+    ),
+    FLAC(
+        ffmpegName = "flac",
+        displayName = "FLAC (Lossless)",
+        supportsCbr = false
+    ),
+    AC3(
+        ffmpegName = "ac3",
+        displayName = "AC3"
+    ),
+    EAC3(
+        ffmpegName = "eac3",
+        displayName = "E-AC3"
+    ),
+    PCM_S16LE(
+        ffmpegName = "pcm_s16le",
+        displayName = "PCM 16-bit",
+        supportsCbr = false
+    ),
+    PCM_S24LE(
+        ffmpegName = "pcm_s24le",
+        displayName = "PCM 24-bit",
+        supportsCbr = false
+    ),
+    ALAC(
+        ffmpegName = "alac",
+        displayName = "ALAC (Apple Lossless)",
+        supportsCbr = false
+    )
+}
+
+/**
+ * Encoder presets for speed/quality tradeoff.
+ */
+enum class EncoderPreset(
+    val ffmpegValue: String,
+    val x264x265Index: Int,
+    val svtAv1Preset: Int?
+) {
+    ULTRAFAST("ultrafast", 0, null),
+    SUPERFAST("superfast", 1, null),
+    VERYFAST("veryfast", 2, null),
+    FASTER("faster", 3, null),
+    FAST("fast", 4, null),
+    MEDIUM("medium", 5, null),
+    SLOW("slow", 6, null),
+    SLOWER("slower", 7, null),
+    VERYSLOW("veryslow", 8, null),
+    PLACEBO("placebo", 9, null),
+
+    // SVT-AV1 specific presets (0-13, lower = slower/better)
+    PRESET_0("0", -1, 0),
+    PRESET_1("1", -1, 1),
+    PRESET_2("2", -1, 2),
+    PRESET_3("3", -1, 3),
+    PRESET_4("4", -1, 4),
+    PRESET_5("5", -1, 5),
+    PRESET_6("6", -1, 6),
+    PRESET_7("7", -1, 7),
+    PRESET_8("8", -1, 8),
+    PRESET_9("9", -1, 9),
+    PRESET_10("10", -1, 10),
+    PRESET_11("11", -1, 11),
+    PRESET_12("12", -1, 12),
+    PRESET_13("13", -1, 13),
+
+    // VP9 quality modes
+    GOOD("good", -1, null),
+    BEST("best", -1, null),
+    REALTIME("realtime", -1, null);
+
+    companion object {
+        fun fromSvtAv1Preset(preset: Int): EncoderPreset = when (preset.coerceIn(0, 13)) {
+            0 -> PRESET_0
+            1 -> PRESET_1
+            2 -> PRESET_2
+            3 -> PRESET_3
+            4 -> PRESET_4
+            5 -> PRESET_5
+            6 -> PRESET_6
+            7 -> PRESET_7
+            8 -> PRESET_8
+            9 -> PRESET_9
+            10 -> PRESET_10
+            11 -> PRESET_11
+            12 -> PRESET_12
+            else -> PRESET_13
+        }
+
+        /** Standard presets for x264/x265. */
+        val x264x265Presets = listOf(
+            ULTRAFAST, SUPERFAST, VERYFAST, FASTER, FAST,
+            MEDIUM, SLOW, SLOWER, VERYSLOW, PLACEBO
+        )
+
+        /** SVT-AV1 presets. */
+        val svtAv1Presets = listOf(
+            PRESET_0, PRESET_1, PRESET_2, PRESET_3, PRESET_4,
+            PRESET_5, PRESET_6, PRESET_7, PRESET_8, PRESET_9,
+            PRESET_10, PRESET_11, PRESET_12, PRESET_13
+        )
+    }
+}

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/model/Format.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/model/Format.kt
@@ -1,0 +1,130 @@
+package io.github.kdroidfilter.ffmpeg.model
+
+/**
+ * Common video resolutions.
+ */
+enum class Resolution(
+    val width: Int,
+    val height: Int,
+    val displayName: String
+) {
+    P360(640, 360, "360p"),
+    P480(854, 480, "480p (SD)"),
+    P720(1280, 720, "720p (HD)"),
+    P1080(1920, 1080, "1080p (Full HD)"),
+    P1440(2560, 1440, "1440p (2K)"),
+    P2160(3840, 2160, "2160p (4K)"),
+    P4320(7680, 4320, "4320p (8K)");
+
+    /**
+     * Generate FFmpeg scale filter string that preserves aspect ratio.
+     * Uses -2 for the variable dimension to ensure divisibility by 2.
+     */
+    fun toScaleFilter(preserveAspectRatio: Boolean = true): String =
+        if (preserveAspectRatio) "scale=-2:$height" else "scale=$width:$height"
+
+    companion object {
+        fun fromHeight(height: Int): Resolution? =
+            entries.minByOrNull { kotlin.math.abs(it.height - height) }
+    }
+}
+
+/**
+ * Pixel formats for video encoding.
+ */
+enum class PixelFormat(
+    val ffmpegValue: String,
+    val displayName: String,
+    val bitDepth: Int
+) {
+    BIT_8("yuv420p", "8-bit (SDR)", 8),
+    BIT_10("yuv420p10le", "10-bit (HDR compatible)", 10);
+
+    companion object {
+        fun fromBitDepth(depth: Int): PixelFormat =
+            if (depth >= 10) BIT_10 else BIT_8
+
+        fun fromFfmpegValue(value: String): PixelFormat? = when {
+            value.contains("10") -> BIT_10
+            else -> BIT_8
+        }
+    }
+}
+
+/**
+ * Audio sample rates.
+ */
+enum class SampleRate(val hz: Int, val displayName: String) {
+    HZ_22050(22050, "22.05 kHz"),
+    HZ_44100(44100, "44.1 kHz (CD quality)"),
+    HZ_48000(48000, "48 kHz (DVD/Broadcast)"),
+    HZ_96000(96000, "96 kHz (Hi-Res)"),
+    HZ_192000(192000, "192 kHz (Hi-Res)");
+
+    val ffmpegValue: String get() = hz.toString()
+
+    companion object {
+        fun fromHz(hz: Int): SampleRate? =
+            entries.minByOrNull { kotlin.math.abs(it.hz - hz) }
+    }
+}
+
+/**
+ * Audio channel configurations.
+ */
+enum class Channels(val count: Int, val displayName: String) {
+    MONO(1, "Mono"),
+    STEREO(2, "Stereo"),
+    SURROUND_5_1(6, "5.1 Surround"),
+    SURROUND_7_1(8, "7.1 Surround");
+
+    val ffmpegValue: String get() = count.toString()
+
+    companion object {
+        fun fromCount(count: Int): Channels? = when (count) {
+            1 -> MONO
+            2 -> STEREO
+            6 -> SURROUND_5_1
+            8 -> SURROUND_7_1
+            else -> null
+        }
+    }
+}
+
+/**
+ * Common container formats.
+ */
+enum class ContainerFormat(
+    val extension: String,
+    val mimeType: String,
+    val displayName: String,
+    val supportsVideo: Boolean = true,
+    val supportsAudio: Boolean = true,
+    val supportsSubtitles: Boolean = false
+) {
+    MP4("mp4", "video/mp4", "MP4", supportsSubtitles = true),
+    MKV("mkv", "video/x-matroska", "Matroska (MKV)", supportsSubtitles = true),
+    WEBM("webm", "video/webm", "WebM"),
+    AVI("avi", "video/x-msvideo", "AVI"),
+    MOV("mov", "video/quicktime", "QuickTime (MOV)", supportsSubtitles = true),
+    FLV("flv", "video/x-flv", "Flash Video (FLV)"),
+    TS("ts", "video/mp2t", "MPEG Transport Stream"),
+    MP3("mp3", "audio/mpeg", "MP3", supportsVideo = false),
+    AAC("aac", "audio/aac", "AAC", supportsVideo = false),
+    M4A("m4a", "audio/mp4", "M4A (AAC)", supportsVideo = false),
+    OGG("ogg", "audio/ogg", "Ogg", supportsVideo = false),
+    OPUS("opus", "audio/opus", "Opus", supportsVideo = false),
+    FLAC("flac", "audio/flac", "FLAC", supportsVideo = false),
+    WAV("wav", "audio/wav", "WAV", supportsVideo = false),
+    SRT("srt", "application/x-subrip", "SubRip", supportsVideo = false, supportsAudio = false, supportsSubtitles = true),
+    ASS("ass", "text/x-ass", "Advanced SubStation Alpha", supportsVideo = false, supportsAudio = false, supportsSubtitles = true),
+    VTT("vtt", "text/vtt", "WebVTT", supportsVideo = false, supportsAudio = false, supportsSubtitles = true);
+
+    companion object {
+        fun fromExtension(ext: String): ContainerFormat? =
+            entries.find { it.extension.equals(ext.removePrefix("."), ignoreCase = true) }
+
+        val videoFormats = entries.filter { it.supportsVideo }
+        val audioFormats = entries.filter { it.supportsAudio && !it.supportsVideo }
+    }
+}

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/model/MediaInfo.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/model/MediaInfo.kt
@@ -1,0 +1,153 @@
+package io.github.kdroidfilter.ffmpeg.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import java.io.File
+import java.time.Duration
+
+/**
+ * Complete media information extracted from a file via FFprobe.
+ */
+data class MediaInfo(
+    val file: File,
+    val format: FormatInfo,
+    val videoStreams: List<VideoStreamInfo>,
+    val audioStreams: List<AudioStreamInfo>,
+    val subtitleStreams: List<SubtitleStreamInfo>
+) {
+    /** Primary video stream, if any. */
+    val primaryVideo: VideoStreamInfo? get() = videoStreams.firstOrNull()
+
+    /** Primary audio stream, if any. */
+    val primaryAudio: AudioStreamInfo? get() = audioStreams.firstOrNull()
+
+    /** Whether the media contains video. */
+    val hasVideo: Boolean get() = videoStreams.isNotEmpty()
+
+    /** Whether the media contains audio. */
+    val hasAudio: Boolean get() = audioStreams.isNotEmpty()
+
+    /** Whether the media contains subtitles. */
+    val hasSubtitles: Boolean get() = subtitleStreams.isNotEmpty()
+
+    /** Media duration. */
+    val duration: Duration? get() = format.duration
+
+    /** File size in bytes. */
+    val fileSize: Long get() = file.length()
+}
+
+/**
+ * Format/container information.
+ */
+data class FormatInfo(
+    val formatName: String?,
+    val formatLongName: String?,
+    val duration: Duration?,
+    val bitRate: Long?,
+    val streamCount: Int
+)
+
+/**
+ * Video stream information.
+ */
+data class VideoStreamInfo(
+    val index: Int,
+    val codec: String?,
+    val codecLongName: String?,
+    val profile: String?,
+    val width: Int?,
+    val height: Int?,
+    val frameRate: Double?,
+    val bitRate: Long?,
+    val pixelFormat: String?,
+    val bitDepth: Int?,
+    val level: Int?,
+    val fieldOrder: String?,
+    val aspectRatio: String?,
+    val hasFilmGrain: Boolean,
+    val title: String?,
+    val language: String?
+) {
+    /** Video resolution (e.g., "1920x1080"). */
+    val resolution: String? get() = if (width != null && height != null) "${width}x${height}" else null
+
+    /** Detect if video is HDR based on pixel format. */
+    val isHdr: Boolean get() = (bitDepth ?: 8) >= 10 || pixelFormat?.contains("10") == true
+}
+
+/**
+ * Audio stream information.
+ */
+data class AudioStreamInfo(
+    val index: Int,
+    val codec: String?,
+    val codecLongName: String?,
+    val profile: String?,
+    val sampleRate: Int?,
+    val channels: Int?,
+    val channelLayout: String?,
+    val bitRate: Long?,
+    val bitDepth: Int?,
+    val title: String?,
+    val language: String?
+)
+
+/**
+ * Subtitle stream information.
+ */
+data class SubtitleStreamInfo(
+    val index: Int,
+    val codec: String?,
+    val codecLongName: String?,
+    val title: String?,
+    val language: String?
+)
+
+// --- FFprobe JSON response models ---
+
+@Serializable
+internal data class FfprobeResponse(
+    val format: FfprobeFormat? = null,
+    val streams: List<FfprobeStream> = emptyList()
+)
+
+@Serializable
+internal data class FfprobeFormat(
+    @SerialName("format_name") val formatName: String? = null,
+    @SerialName("format_long_name") val formatLongName: String? = null,
+    val duration: String? = null,
+    @SerialName("bit_rate") val bitRate: String? = null,
+    @SerialName("nb_streams") val nbStreams: Int? = null
+)
+
+@Serializable
+internal data class FfprobeStream(
+    val index: Int = 0,
+    @SerialName("codec_type") val codecType: String? = null,
+    @SerialName("codec_name") val codecName: String? = null,
+    @SerialName("codec_long_name") val codecLongName: String? = null,
+    val profile: String? = null,
+    val width: Int? = null,
+    val height: Int? = null,
+    @SerialName("pix_fmt") val pixFmt: String? = null,
+    @SerialName("r_frame_rate") val rFrameRate: String? = null,
+    @SerialName("avg_frame_rate") val avgFrameRate: String? = null,
+    @SerialName("bit_rate") val bitRate: String? = null,
+    @SerialName("bits_per_raw_sample") val bitsPerRawSample: String? = null,
+    @SerialName("bits_per_sample") val bitsPerSample: Int? = null,
+    val level: Int? = null,
+    @SerialName("field_order") val fieldOrder: String? = null,
+    @SerialName("display_aspect_ratio") val displayAspectRatio: String? = null,
+    @SerialName("sample_rate") val sampleRate: String? = null,
+    val channels: Int? = null,
+    @SerialName("channel_layout") val channelLayout: String? = null,
+    @SerialName("film_grain") val filmGrain: Int? = null,
+    val tags: FfprobeStreamTags? = null
+)
+
+@Serializable
+internal data class FfprobeStreamTags(
+    val title: String? = null,
+    val language: String? = null
+)

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/util/CommandBuilder.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/util/CommandBuilder.kt
@@ -1,0 +1,348 @@
+package io.github.kdroidfilter.ffmpeg.util
+
+import io.github.kdroidfilter.ffmpeg.core.*
+import io.github.kdroidfilter.ffmpeg.model.*
+import java.io.File
+
+/**
+ * Builds FFmpeg command line arguments from conversion options.
+ */
+object CommandBuilder {
+
+    /**
+     * Build the complete FFmpeg command.
+     *
+     * @param ffmpegPath Path to FFmpeg binary.
+     * @param inputFile Input media file.
+     * @param outputFile Output file path.
+     * @param options Conversion options.
+     * @return List of command arguments.
+     */
+    fun build(
+        ffmpegPath: String,
+        inputFile: File,
+        outputFile: File,
+        options: ConversionOptions
+    ): List<String> = buildList {
+        add(ffmpegPath)
+
+        // Log level
+        add("-loglevel")
+        add(options.logLevel.value)
+
+        // Enable progress stats
+        add("-stats")
+
+        // Hardware acceleration
+        options.hwAccel?.let {
+            add("-hwaccel")
+            add(it)
+        }
+
+        // Input time trimming (before input for efficiency)
+        options.startTime?.let {
+            add("-ss")
+            add(formatDuration(it))
+        }
+
+        // Input file
+        add("-i")
+        add(inputFile.absolutePath)
+
+        // Duration/end time
+        options.duration?.let {
+            add("-t")
+            add(formatDuration(it))
+        }
+        options.endTime?.let {
+            if (options.duration == null) {
+                add("-to")
+                add(formatDuration(it))
+            }
+        }
+
+        // Stream mapping
+        addStreamMapping(this, options.streamSelection)
+
+        // Video encoding options
+        if (options.video != null) {
+            addVideoOptions(this, options.video)
+        } else {
+            add("-vn") // No video
+        }
+
+        // Audio encoding options
+        if (options.audio != null) {
+            addAudioOptions(this, options.audio)
+        } else {
+            add("-an") // No audio
+        }
+
+        // Subtitle options
+        if (options.subtitle != null) {
+            addSubtitleOptions(this, options.subtitle)
+        } else {
+            add("-sn") // No subtitles
+        }
+
+        // Metadata mapping
+        options.mapMetadata?.let {
+            add("-map_metadata")
+            add(it.toString())
+        }
+
+        // Chapter mapping
+        options.mapChapters?.let {
+            add("-map_chapters")
+            add(it.toString())
+        }
+
+        // Custom metadata
+        options.metadata.forEach { (key, value) ->
+            add("-metadata")
+            add("$key=$value")
+        }
+
+        // Output format
+        options.outputFormat?.let {
+            add("-f")
+            add(it)
+        }
+
+        // Overwrite
+        if (options.overwrite) {
+            add("-y")
+        }
+
+        // Extra arguments
+        addAll(options.extraArgs)
+
+        // Output file
+        add(outputFile.absolutePath)
+    }
+
+    private fun addStreamMapping(cmd: MutableList<String>, selection: StreamSelection) {
+        // Video stream
+        when (selection.videoStream) {
+            null -> {
+                cmd.add("-map")
+                cmd.add("0:v:0?")
+            }
+            -1 -> { /* Excluded via -vn */ }
+            else -> {
+                cmd.add("-map")
+                cmd.add("0:v:${selection.videoStream}")
+            }
+        }
+
+        // Audio stream
+        when (selection.audioStream) {
+            null -> {
+                cmd.add("-map")
+                cmd.add("0:a:0?")
+            }
+            -1 -> { /* Excluded via -an */ }
+            else -> {
+                cmd.add("-map")
+                cmd.add("0:a:${selection.audioStream}")
+            }
+        }
+
+        // Subtitle stream
+        when (selection.subtitleStream) {
+            null -> {
+                cmd.add("-map")
+                cmd.add("0:s:0?")
+            }
+            -1 -> { /* Excluded via -sn */ }
+            else -> {
+                cmd.add("-map")
+                cmd.add("0:s:${selection.subtitleStream}")
+            }
+        }
+    }
+
+    private fun addVideoOptions(cmd: MutableList<String>, video: VideoOptions) {
+        when (video.compressionType) {
+            CompressionType.COPY -> {
+                cmd.add("-c:v")
+                cmd.add("copy")
+                return
+            }
+            CompressionType.CRF -> {
+                cmd.add("-c:v")
+                cmd.add(video.encoder.ffmpegName)
+
+                val crf = video.crf ?: video.encoder.defaultCrf
+                cmd.add("-crf")
+                cmd.add(crf.coerceIn(video.encoder.minCrf, video.encoder.maxCrf).toString())
+            }
+            CompressionType.CBR -> {
+                cmd.add("-c:v")
+                cmd.add(video.encoder.ffmpegName)
+
+                video.bitrate?.let {
+                    cmd.add("-b:v")
+                    cmd.add(it.ffmpegValue)
+                }
+            }
+        }
+
+        // Preset
+        if (video.encoder.supportsPreset) {
+            val preset = video.preset ?: video.encoder.defaultPreset
+            cmd.add("-preset")
+            cmd.add(preset.ffmpegValue)
+        }
+
+        // Profile
+        val profile = video.profile ?: video.encoder.getProfile(video.pixelFormat)
+        profile?.let {
+            cmd.add("-profile:v")
+            cmd.add(it)
+        }
+
+        // Pixel format
+        video.pixelFormat?.let {
+            cmd.add("-pix_fmt")
+            cmd.add(it.ffmpegValue)
+        }
+
+        // Frame rate
+        video.frameRate?.let {
+            cmd.add("-r")
+            cmd.add(it.toString())
+        }
+
+        // Resolution
+        video.resolution?.let {
+            cmd.add("-vf")
+            cmd.add(it.toScaleFilter())
+        }
+
+        // Custom filters (append to existing -vf if present)
+        if (video.filters.isNotEmpty()) {
+            val filterString = video.filters.joinToString(",")
+            // Check if we already have a -vf flag (from resolution)
+            val vfIndex = cmd.lastIndexOf("-vf")
+            if (vfIndex >= 0 && vfIndex < cmd.size - 1) {
+                cmd[vfIndex + 1] = "${cmd[vfIndex + 1]},$filterString"
+            } else {
+                cmd.add("-vf")
+                cmd.add(filterString)
+            }
+        }
+    }
+
+    private fun addAudioOptions(cmd: MutableList<String>, audio: AudioOptions) {
+        when (audio.compressionType) {
+            AudioCompressionType.COPY -> {
+                cmd.add("-c:a")
+                cmd.add("copy")
+                return
+            }
+            AudioCompressionType.CBR -> {
+                cmd.add("-c:a")
+                cmd.add(audio.encoder.ffmpegName)
+
+                audio.bitrate?.let {
+                    cmd.add("-b:a")
+                    cmd.add(it.ffmpegValue)
+                }
+            }
+            AudioCompressionType.VBR -> {
+                cmd.add("-c:a")
+                cmd.add(audio.encoder.ffmpegName)
+
+                val vbr = audio.vbr ?: audio.encoder.defaultVbr
+                vbr?.let {
+                    // Different encoders use different VBR flags
+                    when (audio.encoder) {
+                        AudioEncoder.AAC_FDK -> {
+                            cmd.add("-vbr")
+                            cmd.add(it.toString())
+                        }
+                        AudioEncoder.MP3 -> {
+                            cmd.add("-q:a")
+                            cmd.add(it.toString())
+                        }
+                        AudioEncoder.VORBIS -> {
+                            cmd.add("-q:a")
+                            cmd.add(it.toString())
+                        }
+                        else -> {}
+                    }
+                }
+            }
+        }
+
+        // Sample rate
+        audio.sampleRate?.let {
+            cmd.add("-ar")
+            cmd.add(it.ffmpegValue)
+        }
+
+        // Channels
+        audio.channels?.let {
+            cmd.add("-ac")
+            cmd.add(it.ffmpegValue)
+
+            // Opus needs mapping_family for surround
+            if (audio.encoder == AudioEncoder.OPUS && it.count > 2) {
+                cmd.add("-mapping_family")
+                cmd.add("1")
+            }
+        }
+
+        // Audio filters
+        if (audio.filters.isNotEmpty()) {
+            cmd.add("-af")
+            cmd.add(audio.filters.joinToString(","))
+        }
+    }
+
+    private fun addSubtitleOptions(cmd: MutableList<String>, subtitle: SubtitleOptions) {
+        if (subtitle.copy) {
+            cmd.add("-c:s")
+            cmd.add("copy")
+        } else {
+            subtitle.encoder?.let {
+                cmd.add("-c:s")
+                cmd.add(it)
+            }
+        }
+    }
+
+    /**
+     * Build FFprobe command for media analysis.
+     */
+    fun buildProbeCommand(
+        ffprobePath: String,
+        inputFile: File
+    ): List<String> = listOf(
+        ffprobePath,
+        "-v", "quiet",
+        "-print_format", "json",
+        "-show_format",
+        "-show_streams",
+        inputFile.absolutePath
+    )
+
+    private fun formatDuration(duration: java.time.Duration): String {
+        val hours = duration.toHours()
+        val minutes = (duration.toMinutes() % 60)
+        val seconds = (duration.seconds % 60)
+        val millis = (duration.toMillis() % 1000)
+        return String.format("%02d:%02d:%02d.%03d", hours, minutes, seconds, millis)
+    }
+}
+
+/**
+ * Extension function to add a parameter only if the value is not null.
+ */
+internal fun MutableList<String>.addCmd(param: String, value: String?) {
+    value?.let {
+        add(param)
+        add(it)
+    }
+}

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/util/PlatformUtils.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/util/PlatformUtils.kt
@@ -1,0 +1,296 @@
+package io.github.kdroidfilter.ffmpeg.util
+
+import io.github.kdroidfilter.logging.debugln
+import io.github.kdroidfilter.logging.errorln
+import io.github.kdroidfilter.network.HttpsConnectionFactory
+import io.github.kdroidfilter.platformtools.OperatingSystem
+import io.github.kdroidfilter.platformtools.getOperatingSystem
+import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.databasesDir
+import io.github.vinceglb.filekit.path
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.channels.Channels
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
+
+/**
+ * Platform utilities for FFmpeg binary management.
+ */
+object PlatformUtils {
+
+    private fun getDataDir(): String = FileKit.databasesDir.path
+
+    // --- FFmpeg Paths ---
+
+    fun getDefaultFfmpegPath(): String {
+        val dir = File(getDataDir(), "ffmpeg/bin")
+        val exe = if (getOperatingSystem() == OperatingSystem.WINDOWS) "ffmpeg.exe" else "ffmpeg"
+        return File(dir, exe).absolutePath
+    }
+
+    fun getDefaultFfprobePath(): String {
+        val dir = File(getDataDir(), "ffmpeg/bin")
+        val exe = if (getOperatingSystem() == OperatingSystem.WINDOWS) "ffprobe.exe" else "ffprobe"
+        return File(dir, exe).absolutePath
+    }
+
+    // --- System PATH Detection ---
+
+    suspend fun findFfmpegInSystemPath(): String? = withContext(Dispatchers.IO) {
+        val cmd = if (getOperatingSystem() == OperatingSystem.WINDOWS)
+            listOf("where", "ffmpeg")
+        else
+            listOf("which", "ffmpeg")
+
+        runCatching {
+            val p = ProcessBuilder(cmd).redirectErrorStream(true).start()
+            val exited = withTimeoutOrNull(1500) { p.waitFor() }
+            if (exited == null) {
+                p.destroyForcibly()
+                return@withContext null
+            }
+            val out = p.inputStream.bufferedReader().readText().trim()
+            if (p.exitValue() == 0 && out.isNotBlank()) out.lineSequence().firstOrNull()?.trim() else null
+        }.getOrNull()
+    }
+
+    suspend fun findFfprobeInSystemPath(): String? = withContext(Dispatchers.IO) {
+        val cmd = if (getOperatingSystem() == OperatingSystem.WINDOWS)
+            listOf("where", "ffprobe")
+        else
+            listOf("which", "ffprobe")
+
+        runCatching {
+            val p = ProcessBuilder(cmd).redirectErrorStream(true).start()
+            val exited = withTimeoutOrNull(1500) { p.waitFor() }
+            if (exited == null) {
+                p.destroyForcibly()
+                return@withContext null
+            }
+            val out = p.inputStream.bufferedReader().readText().trim()
+            if (p.exitValue() == 0 && out.isNotBlank()) out.lineSequence().firstOrNull()?.trim() else null
+        }.getOrNull()
+    }
+
+    // --- Version Detection ---
+
+    suspend fun getFfmpegVersion(path: String): String? = withContext(Dispatchers.IO) {
+        runCatching {
+            val p = ProcessBuilder(listOf(path, "-version")).redirectErrorStream(true).start()
+            val exited = withTimeoutOrNull(2_000) { p.waitFor() }
+            if (exited == null) {
+                p.destroyForcibly()
+                return@withContext null
+            }
+            val out = p.inputStream.bufferedReader().readText().trim()
+            if (p.exitValue() == 0 && out.isNotBlank()) {
+                // Parse "ffmpeg version X.Y.Z ..."
+                out.lineSequence().firstOrNull()?.let { line ->
+                    Regex("""ffmpeg version (\S+)""").find(line)?.groupValues?.get(1) ?: line
+                }
+            } else null
+        }.getOrNull()
+    }
+
+    suspend fun getFfprobeVersion(path: String): String? = withContext(Dispatchers.IO) {
+        runCatching {
+            val p = ProcessBuilder(listOf(path, "-version")).redirectErrorStream(true).start()
+            val exited = withTimeoutOrNull(2_000) { p.waitFor() }
+            if (exited == null) {
+                p.destroyForcibly()
+                return@withContext null
+            }
+            val out = p.inputStream.bufferedReader().readText().trim()
+            if (p.exitValue() == 0 && out.isNotBlank()) {
+                out.lineSequence().firstOrNull()?.let { line ->
+                    Regex("""ffprobe version (\S+)""").find(line)?.groupValues?.get(1) ?: line
+                }
+            } else null
+        }.getOrNull()
+    }
+
+    // --- Asset Pattern Detection ---
+
+    fun getFfmpegAssetPatternForSystem(): String? {
+        val os = getOperatingSystem()
+        val arch = (System.getProperty("os.arch") ?: "").lowercase()
+        val isArm64 = arch.contains("aarch64") || arch.contains("arm64")
+
+        return when (os) {
+            OperatingSystem.WINDOWS -> when {
+                isArm64 -> "winarm64-gpl.zip"
+                arch.contains("32") || (arch.contains("x86") && !arch.contains("64")) -> "win32-gpl.zip"
+                else -> "win64-gpl.zip"
+            }
+            OperatingSystem.LINUX -> if (isArm64) "linuxarm64-gpl.tar.xz" else "linux64-gpl.tar.xz"
+            OperatingSystem.MACOS -> if (isArm64) "ffmpeg-darwin-arm64" else "ffmpeg-darwin-x64"
+            else -> null
+        }
+    }
+
+    // --- Download & Installation ---
+
+    suspend fun downloadAndInstallFfmpeg(
+        assetPattern: String,
+        forceDownload: Boolean,
+        ffmpegFetcher: io.github.kdroidfilter.platformtools.releasefetcher.github.GitHubReleaseFetcher,
+        onProgress: ((bytesRead: Long, totalBytes: Long?) -> Unit)? = null
+    ): String? = withContext(Dispatchers.IO) {
+        val baseDir = File(getDataDir(), "ffmpeg")
+        val binDir = File(baseDir, "bin")
+        val targetFfmpeg = File(binDir, if (getOperatingSystem() == OperatingSystem.WINDOWS) "ffmpeg.exe" else "ffmpeg")
+        val targetFfprobe = File(binDir, if (getOperatingSystem() == OperatingSystem.WINDOWS) "ffprobe.exe" else "ffprobe")
+
+        if (!forceDownload && targetFfmpeg.exists() && getFfmpegVersion(targetFfmpeg.absolutePath) != null) {
+            if (getOperatingSystem() == OperatingSystem.MACOS || targetFfprobe.exists()) {
+                return@withContext targetFfmpeg.absolutePath
+            }
+        }
+
+        baseDir.mkdirs()
+        binDir.mkdirs()
+
+        val os = getOperatingSystem()
+
+        try {
+            val release = ffmpegFetcher.getLatestRelease()
+                ?: error("Could not fetch FFmpeg release from GitHub")
+
+            val asset = if (os == OperatingSystem.MACOS) {
+                release.assets.find { it.name == assetPattern }
+            } else {
+                release.assets.find { it.name.endsWith(assetPattern) && !it.name.contains("shared") }
+            } ?: error("Asset matching pattern '$assetPattern' not found")
+
+            val url = asset.browser_download_url
+            val archive = File(baseDir, asset.name)
+
+            downloadFile(url, archive, onProgress)
+
+            if (os == OperatingSystem.MACOS) {
+                archive.copyTo(targetFfmpeg, overwrite = true)
+            } else {
+                if (archive.name.endsWith(".zip")) extractZip(archive, baseDir)
+                else if (archive.name.endsWith(".tar.xz")) extractTarXz(archive, baseDir)
+                else error("Unsupported FFmpeg archive: ${archive.name}")
+
+                val foundFfmpeg = baseDir.walkTopDown()
+                    .firstOrNull { it.isFile && it.name.matches(Regex("^ffmpeg(\\.exe)?$")) && it.canRead() }
+                    ?: error("FFmpeg binary not found after extraction")
+                foundFfmpeg.copyTo(targetFfmpeg, overwrite = true)
+
+                val foundFfprobe = baseDir.walkTopDown()
+                    .firstOrNull { it.isFile && it.name.matches(Regex("^ffprobe(\\.exe)?$")) && it.canRead() }
+                foundFfprobe?.copyTo(targetFfprobe, overwrite = true)
+            }
+
+            if (os != OperatingSystem.WINDOWS) {
+                makeExecutable(targetFfmpeg)
+                if (targetFfprobe.exists()) makeExecutable(targetFfprobe)
+            }
+
+            getFfmpegVersion(targetFfmpeg.absolutePath) ?: error("FFmpeg is not runnable after installation")
+            targetFfmpeg.absolutePath
+        } catch (t: Throwable) {
+            errorln { "Failed to download/install FFmpeg: ${t.stackTraceToString()}" }
+            null
+        }
+    }
+
+    // --- Helper Functions ---
+
+    private suspend fun downloadFile(
+        url: String,
+        dest: File,
+        onProgress: ((bytesRead: Long, totalBytes: Long?) -> Unit)? = null
+    ) = withContext(Dispatchers.IO) {
+        dest.parentFile?.mkdirs()
+
+        val uri = java.net.URI.create(url)
+        val conn = HttpsConnectionFactory.openConnection(uri.toURL()) {
+            connectTimeout = 12_000
+            readTimeout = 24_000
+            instanceFollowRedirects = true
+            setRequestProperty("User-Agent", "kdroidFilter-ffmpeg/1.0")
+        }
+
+        val total = conn.getHeaderFieldLong("Content-Length", -1L).takeIf { it > 0 }
+        conn.inputStream.use { input ->
+            Channels.newChannel(input).use { rch ->
+                java.io.FileOutputStream(dest).use { fos ->
+                    val buffer = ByteBuffer.allocateDirect(1024 * 64)
+                    var readTotal = 0L
+                    while (isActive) {
+                        buffer.clear()
+                        val n = rch.read(buffer)
+                        if (n <= 0) break
+                        buffer.flip()
+                        fos.channel.write(buffer)
+                        readTotal += n
+                        onProgress?.invoke(readTotal, total)
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun makeExecutable(file: File) = withContext(Dispatchers.IO) {
+        try {
+            val path = file.toPath()
+            val perms = Files.getPosixFilePermissions(path).toMutableSet()
+            perms.add(PosixFilePermission.OWNER_EXECUTE)
+            perms.add(PosixFilePermission.GROUP_EXECUTE)
+            perms.add(PosixFilePermission.OTHERS_EXECUTE)
+            Files.setPosixFilePermissions(path, perms)
+
+            if (getOperatingSystem() == OperatingSystem.MACOS) {
+                runCatching {
+                    ProcessBuilder("xattr", "-d", "com.apple.quarantine", file.absolutePath)
+                        .redirectErrorStream(true)
+                        .start()
+                        .waitFor()
+                }
+            }
+        } catch (_: UnsupportedOperationException) {
+            Runtime.getRuntime().exec(arrayOf("chmod", "+x", file.absolutePath)).waitFor()
+        }
+    }
+
+    private fun extractZip(zipFile: File, destDir: File) {
+        java.util.zip.ZipFile(zipFile).use { zip ->
+            zip.entries().asSequence().forEach { entry ->
+                val target = File(destDir, entry.name)
+                if (entry.isDirectory) {
+                    target.mkdirs()
+                } else {
+                    target.parentFile?.mkdirs()
+                    zip.getInputStream(entry).use { input ->
+                        target.outputStream().use { output ->
+                            input.copyTo(output)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun extractTarXz(archive: File, destDir: File) = withContext(Dispatchers.IO) {
+        val process = ProcessBuilder("tar", "-xf", archive.absolutePath, "-C", destDir.absolutePath)
+            .redirectErrorStream(true)
+            .start()
+
+        val exited = withTimeoutOrNull(60_000) { process.waitFor() }
+        if (exited == null) {
+            process.destroyForcibly()
+            error("Tar extraction timed out")
+        }
+        if (process.exitValue() != 0) {
+            error("Tar extraction failed: ${process.inputStream.bufferedReader().readText()}")
+        }
+    }
+}

--- a/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/util/ProgressParser.kt
+++ b/ffmpeg/src/jvmMain/kotlin/io/github/kdroidfilter/ffmpeg/util/ProgressParser.kt
@@ -1,0 +1,146 @@
+package io.github.kdroidfilter.ffmpeg.util
+
+import java.time.Duration
+
+/**
+ * Parses FFmpeg progress output from stderr.
+ */
+object ProgressParser {
+
+    // time=00:01:23.45 format
+    private val timeRegex = Regex("""time=(\d+):(\d+):(\d+)\.(\d+)""")
+
+    // speed=1.5x format
+    private val speedRegex = Regex("""speed=\s*([\d.]+)x""")
+
+    // fps=30 format
+    private val fpsRegex = Regex("""fps=\s*([\d.]+)""")
+
+    // bitrate=1234.5kbits/s format
+    private val bitrateRegex = Regex("""bitrate=\s*([\d.]+)(k?bits/s)""")
+
+    // frame=1234 format
+    private val frameRegex = Regex("""frame=\s*(\d+)""")
+
+    // size=1234kB format
+    private val sizeRegex = Regex("""size=\s*([\d.]+)(k?B)""")
+
+    /**
+     * Data class holding parsed progress information.
+     */
+    data class ProgressData(
+        val time: Duration,
+        val speed: Double?,
+        val fps: Double?,
+        val bitrate: Long?,
+        val frame: Long?,
+        val size: Long?
+    )
+
+    /**
+     * Parse a line of FFmpeg output for progress information.
+     * Returns null if the line doesn't contain progress data.
+     */
+    fun parse(line: String): ProgressData? {
+        val timeMatch = timeRegex.find(line) ?: return null
+
+        val hours = timeMatch.groupValues[1].toLongOrNull() ?: 0
+        val minutes = timeMatch.groupValues[2].toLongOrNull() ?: 0
+        val seconds = timeMatch.groupValues[3].toLongOrNull() ?: 0
+        val centiseconds = timeMatch.groupValues[4].padEnd(2, '0').take(2).toLongOrNull() ?: 0
+
+        val time = Duration.ofHours(hours)
+            .plusMinutes(minutes)
+            .plusSeconds(seconds)
+            .plusMillis(centiseconds * 10)
+
+        val speed = speedRegex.find(line)?.groupValues?.get(1)?.toDoubleOrNull()
+        val fps = fpsRegex.find(line)?.groupValues?.get(1)?.toDoubleOrNull()
+        val bitrate = parseBitrate(line)
+        val frame = frameRegex.find(line)?.groupValues?.get(1)?.toLongOrNull()
+        val size = parseSize(line)
+
+        return ProgressData(
+            time = time,
+            speed = speed,
+            fps = fps,
+            bitrate = bitrate,
+            frame = frame,
+            size = size
+        )
+    }
+
+    private fun parseBitrate(line: String): Long? {
+        val match = bitrateRegex.find(line) ?: return null
+        val value = match.groupValues[1].toDoubleOrNull() ?: return null
+        val unit = match.groupValues[2]
+
+        // Convert to bits per second
+        return when {
+            unit.startsWith("k") -> (value * 1000).toLong()
+            else -> value.toLong()
+        }
+    }
+
+    private fun parseSize(line: String): Long? {
+        val match = sizeRegex.find(line) ?: return null
+        val value = match.groupValues[1].toDoubleOrNull() ?: return null
+        val unit = match.groupValues[2]
+
+        // Convert to bytes
+        return when {
+            unit.startsWith("k") -> (value * 1024).toLong()
+            else -> value.toLong()
+        }
+    }
+
+    /**
+     * Calculate progress percentage based on processed time and total duration.
+     */
+    fun calculatePercent(processedTime: Duration, totalDuration: Duration?): Double? {
+        if (totalDuration == null || totalDuration.isZero || totalDuration.isNegative) {
+            return null
+        }
+        val percent = processedTime.toMillis().toDouble() / totalDuration.toMillis().toDouble() * 100
+        return percent.coerceIn(0.0, 100.0)
+    }
+}
+
+/**
+ * Diagnoses common FFmpeg errors from output.
+ */
+object ErrorDiagnostics {
+
+    private val errorPatterns = listOf(
+        "No such file or directory" to "Input file not found",
+        "Invalid data found" to "Invalid or corrupted input file",
+        "Permission denied" to "Permission denied accessing file",
+        "Unknown encoder" to "Encoder not available (may need to be compiled into FFmpeg)",
+        "Encoder .* not found" to "Encoder not available",
+        "does not contain any stream" to "Input file has no media streams",
+        "Output file is empty" to "Encoding failed - no output produced",
+        "Option .* not found" to "Invalid FFmpeg option",
+        "Unrecognized option" to "Unrecognized FFmpeg option",
+        "Could not find codec" to "Codec not found",
+        "Decoder .* not found" to "Decoder not available",
+        "Error .* codec" to "Codec error",
+        "Error opening" to "Could not open file",
+        "Unable to find a suitable output format" to "Unknown output format",
+        "Cannot allocate memory" to "Out of memory",
+        "Invalid argument" to "Invalid argument provided"
+    )
+
+    /**
+     * Analyze FFmpeg output lines to find a human-readable error message.
+     */
+    fun diagnose(lines: List<String>): String? {
+        for (line in lines.reversed()) {
+            for ((pattern, message) in errorPatterns) {
+                if (Regex(pattern, RegexOption.IGNORE_CASE).containsMatchIn(line)) {
+                    return message
+                }
+            }
+        }
+        return null
+    }
+}

--- a/ffmpeg/src/jvmTest/kotlin/io/github/kdroidfilter/ffmpeg/CommandBuilderTest.kt
+++ b/ffmpeg/src/jvmTest/kotlin/io/github/kdroidfilter/ffmpeg/CommandBuilderTest.kt
@@ -1,0 +1,161 @@
+package io.github.kdroidfilter.ffmpeg
+
+import io.github.kdroidfilter.ffmpeg.core.*
+import io.github.kdroidfilter.ffmpeg.model.*
+import io.github.kdroidfilter.ffmpeg.util.CommandBuilder
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CommandBuilderTest {
+
+    private val ffmpegPath = "/usr/bin/ffmpeg"
+    private val inputFile = File("/input/video.mkv")
+    private val outputFile = File("/output/video.mp4")
+
+    @Test
+    fun `build basic h264 command`() {
+        val options = ConversionOptions.h264(crf = 23, preset = EncoderPreset.MEDIUM)
+        val cmd = CommandBuilder.build(ffmpegPath, inputFile, outputFile, options)
+
+        assertTrue(cmd.contains("-c:v"))
+        assertTrue(cmd.contains("libx264"))
+        assertTrue(cmd.contains("-crf"))
+        assertTrue(cmd.contains("23"))
+        assertTrue(cmd.contains("-preset"))
+        assertTrue(cmd.contains("medium"))
+        assertTrue(cmd.contains("-y")) // overwrite
+    }
+
+    @Test
+    fun `build h265 command`() {
+        val options = ConversionOptions.h265(crf = 28, preset = EncoderPreset.SLOW)
+        val cmd = CommandBuilder.build(ffmpegPath, inputFile, outputFile, options)
+
+        assertTrue(cmd.contains("libx265"))
+        assertTrue(cmd.contains("28"))
+        assertTrue(cmd.contains("slow"))
+    }
+
+    @Test
+    fun `build audio only command`() {
+        val options = ConversionOptions.audioMp3(bitrate = AudioBitrate.K320)
+        val cmd = CommandBuilder.build(ffmpegPath, inputFile, outputFile, options)
+
+        assertTrue(cmd.contains("-vn")) // no video
+        assertTrue(cmd.contains("-c:a"))
+        assertTrue(cmd.contains("libmp3lame"))
+        assertTrue(cmd.contains("-b:a"))
+        assertTrue(cmd.contains("320k"))
+    }
+
+    @Test
+    fun `build copy command`() {
+        val options = ConversionOptions.copy()
+        val cmd = CommandBuilder.build(ffmpegPath, inputFile, outputFile, options)
+
+        val videoEncoderIndex = cmd.indexOf("-c:v")
+        assertTrue(videoEncoderIndex >= 0)
+        assertEquals("copy", cmd[videoEncoderIndex + 1])
+
+        val audioEncoderIndex = cmd.indexOf("-c:a")
+        assertTrue(audioEncoderIndex >= 0)
+        assertEquals("copy", cmd[audioEncoderIndex + 1])
+    }
+
+    @Test
+    fun `build command with trim options`() {
+        val options = ConversionOptions(
+            startTime = java.time.Duration.ofSeconds(30),
+            duration = java.time.Duration.ofMinutes(5)
+        )
+        val cmd = CommandBuilder.build(ffmpegPath, inputFile, outputFile, options)
+
+        assertTrue(cmd.contains("-ss"))
+        assertTrue(cmd.contains("00:00:30.000"))
+        assertTrue(cmd.contains("-t"))
+        assertTrue(cmd.contains("00:05:00.000"))
+    }
+
+    @Test
+    fun `build command with resolution scaling`() {
+        val options = ConversionOptions(
+            video = VideoOptions(
+                encoder = VideoEncoder.H264,
+                resolution = Resolution.P1080
+            )
+        )
+        val cmd = CommandBuilder.build(ffmpegPath, inputFile, outputFile, options)
+
+        assertTrue(cmd.contains("-vf"))
+        assertTrue(cmd.any { it.contains("scale") && it.contains("1080") })
+    }
+
+    @Test
+    fun `build command with audio options`() {
+        val options = ConversionOptions(
+            video = null,
+            audio = AudioOptions(
+                encoder = AudioEncoder.AAC,
+                bitrate = AudioBitrate.K256,
+                sampleRate = SampleRate.HZ_48000,
+                channels = Channels.STEREO
+            )
+        )
+        val cmd = CommandBuilder.build(ffmpegPath, inputFile, outputFile, options)
+
+        assertTrue(cmd.contains("-c:a"))
+        assertTrue(cmd.contains("aac"))
+        assertTrue(cmd.contains("-b:a"))
+        assertTrue(cmd.contains("256k"))
+        assertTrue(cmd.contains("-ar"))
+        assertTrue(cmd.contains("48000"))
+        assertTrue(cmd.contains("-ac"))
+        assertTrue(cmd.contains("2"))
+    }
+
+    @Test
+    fun `build command with stream selection`() {
+        val options = ConversionOptions(
+            streamSelection = StreamSelection(
+                videoStream = 0,
+                audioStream = 1,
+                subtitleStream = -1
+            )
+        )
+        val cmd = CommandBuilder.build(ffmpegPath, inputFile, outputFile, options)
+
+        assertTrue(cmd.contains("-map"))
+        assertTrue(cmd.contains("0:v:0"))
+        assertTrue(cmd.contains("0:a:1"))
+        assertTrue(cmd.contains("-sn")) // subtitle excluded
+    }
+
+    @Test
+    fun `build command with metadata`() {
+        val options = ConversionOptions(
+            metadata = mapOf(
+                "title" to "My Video",
+                "artist" to "Test Artist"
+            )
+        )
+        val cmd = CommandBuilder.build(ffmpegPath, inputFile, outputFile, options)
+
+        assertTrue(cmd.contains("-metadata"))
+        assertTrue(cmd.contains("title=My Video"))
+        assertTrue(cmd.contains("artist=Test Artist"))
+    }
+
+    @Test
+    fun `build ffprobe command`() {
+        val cmd = CommandBuilder.buildProbeCommand("/usr/bin/ffprobe", inputFile)
+
+        assertEquals("/usr/bin/ffprobe", cmd[0])
+        assertTrue(cmd.contains("-print_format"))
+        assertTrue(cmd.contains("json"))
+        assertTrue(cmd.contains("-show_format"))
+        assertTrue(cmd.contains("-show_streams"))
+        assertTrue(cmd.contains(inputFile.absolutePath))
+    }
+}

--- a/ffmpeg/src/jvmTest/kotlin/io/github/kdroidfilter/ffmpeg/EncoderTest.kt
+++ b/ffmpeg/src/jvmTest/kotlin/io/github/kdroidfilter/ffmpeg/EncoderTest.kt
@@ -1,0 +1,122 @@
+package io.github.kdroidfilter.ffmpeg
+
+import io.github.kdroidfilter.ffmpeg.model.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class EncoderTest {
+
+    @Test
+    fun `video encoder ffmpeg names are correct`() {
+        assertEquals("libx264", VideoEncoder.H264.ffmpegName)
+        assertEquals("libx265", VideoEncoder.H265.ffmpegName)
+        assertEquals("libsvtav1", VideoEncoder.AV1.ffmpegName)
+        assertEquals("libvpx-vp9", VideoEncoder.VP9.ffmpegName)
+    }
+
+    @Test
+    fun `video encoder CRF defaults are sensible`() {
+        assertEquals(23, VideoEncoder.H264.defaultCrf)
+        assertEquals(28, VideoEncoder.H265.defaultCrf)
+        assertEquals(35, VideoEncoder.AV1.defaultCrf)
+    }
+
+    @Test
+    fun `video encoder profiles for pixel format`() {
+        assertEquals("high", VideoEncoder.H264.getProfile(PixelFormat.BIT_8))
+        assertEquals("high10", VideoEncoder.H264.getProfile(PixelFormat.BIT_10))
+        assertEquals("main", VideoEncoder.H265.getProfile(PixelFormat.BIT_8))
+        assertEquals("main10", VideoEncoder.H265.getProfile(PixelFormat.BIT_10))
+        assertEquals("0", VideoEncoder.AV1.getProfile(null))
+        assertNull(VideoEncoder.VP9.getProfile(null))
+    }
+
+    @Test
+    fun `audio encoder ffmpeg names are correct`() {
+        assertEquals("aac", AudioEncoder.AAC.ffmpegName)
+        assertEquals("libfdk_aac", AudioEncoder.AAC_FDK.ffmpegName)
+        assertEquals("libmp3lame", AudioEncoder.MP3.ffmpegName)
+        assertEquals("libopus", AudioEncoder.OPUS.ffmpegName)
+        assertEquals("flac", AudioEncoder.FLAC.ffmpegName)
+    }
+
+    @Test
+    fun `encoder preset values`() {
+        assertEquals("ultrafast", EncoderPreset.ULTRAFAST.ffmpegValue)
+        assertEquals("medium", EncoderPreset.MEDIUM.ffmpegValue)
+        assertEquals("veryslow", EncoderPreset.VERYSLOW.ffmpegValue)
+        assertEquals("6", EncoderPreset.PRESET_6.ffmpegValue)
+    }
+
+    @Test
+    fun `svt-av1 preset from int`() {
+        assertEquals(EncoderPreset.PRESET_0, EncoderPreset.fromSvtAv1Preset(0))
+        assertEquals(EncoderPreset.PRESET_6, EncoderPreset.fromSvtAv1Preset(6))
+        assertEquals(EncoderPreset.PRESET_13, EncoderPreset.fromSvtAv1Preset(13))
+        assertEquals(EncoderPreset.PRESET_13, EncoderPreset.fromSvtAv1Preset(100)) // capped
+        assertEquals(EncoderPreset.PRESET_0, EncoderPreset.fromSvtAv1Preset(-5)) // capped
+    }
+
+    @Test
+    fun `video bitrate values`() {
+        assertEquals(5_000_000L, VideoBitrate.M5.bitsPerSecond)
+        assertEquals("5M", VideoBitrate.M5.ffmpegValue)
+        assertEquals(20_000_000L, VideoBitrate.M20.bitsPerSecond)
+        assertEquals("20M", VideoBitrate.M20.ffmpegValue)
+    }
+
+    @Test
+    fun `audio bitrate values`() {
+        assertEquals(192_000L, AudioBitrate.K192.bitsPerSecond)
+        assertEquals("192k", AudioBitrate.K192.ffmpegValue)
+        assertEquals(320_000L, AudioBitrate.K320.bitsPerSecond)
+        assertEquals("320k", AudioBitrate.K320.ffmpegValue)
+    }
+
+    @Test
+    fun `resolution values`() {
+        assertEquals(1920, Resolution.P1080.width)
+        assertEquals(1080, Resolution.P1080.height)
+        assertEquals("1080p (Full HD)", Resolution.P1080.displayName)
+        assertEquals("scale=-2:1080", Resolution.P1080.toScaleFilter())
+    }
+
+    @Test
+    fun `pixel format values`() {
+        assertEquals("yuv420p", PixelFormat.BIT_8.ffmpegValue)
+        assertEquals(8, PixelFormat.BIT_8.bitDepth)
+        assertEquals("yuv420p10le", PixelFormat.BIT_10.ffmpegValue)
+        assertEquals(10, PixelFormat.BIT_10.bitDepth)
+    }
+
+    @Test
+    fun `pixel format from bit depth`() {
+        assertEquals(PixelFormat.BIT_8, PixelFormat.fromBitDepth(8))
+        assertEquals(PixelFormat.BIT_10, PixelFormat.fromBitDepth(10))
+        assertEquals(PixelFormat.BIT_10, PixelFormat.fromBitDepth(12))
+    }
+
+    @Test
+    fun `sample rate values`() {
+        assertEquals(44100, SampleRate.HZ_44100.hz)
+        assertEquals("44100", SampleRate.HZ_44100.ffmpegValue)
+        assertEquals(48000, SampleRate.HZ_48000.hz)
+    }
+
+    @Test
+    fun `channels values`() {
+        assertEquals(2, Channels.STEREO.count)
+        assertEquals("2", Channels.STEREO.ffmpegValue)
+        assertEquals(6, Channels.SURROUND_5_1.count)
+    }
+
+    @Test
+    fun `container format from extension`() {
+        assertEquals(ContainerFormat.MP4, ContainerFormat.fromExtension("mp4"))
+        assertEquals(ContainerFormat.MP4, ContainerFormat.fromExtension(".mp4"))
+        assertEquals(ContainerFormat.MKV, ContainerFormat.fromExtension("mkv"))
+        assertEquals(ContainerFormat.MP3, ContainerFormat.fromExtension("mp3"))
+        assertNull(ContainerFormat.fromExtension("xyz"))
+    }
+}

--- a/ffmpeg/src/jvmTest/kotlin/io/github/kdroidfilter/ffmpeg/ProgressParserTest.kt
+++ b/ffmpeg/src/jvmTest/kotlin/io/github/kdroidfilter/ffmpeg/ProgressParserTest.kt
@@ -1,0 +1,140 @@
+package io.github.kdroidfilter.ffmpeg
+
+import io.github.kdroidfilter.ffmpeg.util.ErrorDiagnostics
+import io.github.kdroidfilter.ffmpeg.util.ProgressParser
+import java.time.Duration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class ProgressParserTest {
+
+    @Test
+    fun `parse basic progress line`() {
+        val line = "frame=  500 fps=30.0 q=28.0 size=    1024kB time=00:00:16.67 bitrate= 502.4kbits/s speed=1.00x"
+        val progress = ProgressParser.parse(line)
+
+        assertNotNull(progress)
+        assertEquals(Duration.ofMillis(16670), progress.time)
+        assertEquals(1.0, progress.speed)
+        assertEquals(30.0, progress.fps)
+        assertNotNull(progress.bitrate)
+    }
+
+    @Test
+    fun `parse progress with different time formats`() {
+        val line1 = "time=01:30:45.50 speed=2.5x"
+        val progress1 = ProgressParser.parse(line1)
+        assertNotNull(progress1)
+        assertEquals(Duration.ofHours(1).plusMinutes(30).plusSeconds(45).plusMillis(500), progress1.time)
+        assertEquals(2.5, progress1.speed)
+
+        val line2 = "time=00:05:30.00 speed=0.8x"
+        val progress2 = ProgressParser.parse(line2)
+        assertNotNull(progress2)
+        assertEquals(Duration.ofMinutes(5).plusSeconds(30), progress2.time)
+        assertEquals(0.8, progress2.speed)
+    }
+
+    @Test
+    fun `parse progress without speed`() {
+        val line = "frame=100 time=00:00:10.00"
+        val progress = ProgressParser.parse(line)
+
+        assertNotNull(progress)
+        assertEquals(Duration.ofSeconds(10), progress.time)
+        assertNull(progress.speed)
+    }
+
+    @Test
+    fun `return null for non-progress line`() {
+        val lines = listOf(
+            "Input #0, matroska,webm, from 'input.mkv':",
+            "  Duration: 01:30:00.00, start: 0.000000, bitrate: 5000 kb/s",
+            "Stream #0:0: Video: h264 (High)",
+            "Press [q] to stop, [?] for help"
+        )
+
+        lines.forEach { line ->
+            assertNull(ProgressParser.parse(line))
+        }
+    }
+
+    @Test
+    fun `calculate percent correctly`() {
+        val processed = Duration.ofMinutes(5)
+        val total = Duration.ofMinutes(10)
+
+        val percent = ProgressParser.calculatePercent(processed, total)
+        assertEquals(50.0, percent)
+    }
+
+    @Test
+    fun `calculate percent returns null for zero duration`() {
+        val processed = Duration.ofMinutes(5)
+        val total = Duration.ZERO
+
+        assertNull(ProgressParser.calculatePercent(processed, total))
+    }
+
+    @Test
+    fun `calculate percent caps at 100`() {
+        val processed = Duration.ofMinutes(15)
+        val total = Duration.ofMinutes(10)
+
+        val percent = ProgressParser.calculatePercent(processed, total)
+        assertEquals(100.0, percent)
+    }
+
+    @Test
+    fun `parse bitrate correctly`() {
+        val line = "time=00:01:00.00 bitrate=1500.5kbits/s speed=1.0x"
+        val progress = ProgressParser.parse(line)
+
+        assertNotNull(progress)
+        assertNotNull(progress.bitrate)
+        assertEquals(1500500L, progress.bitrate)
+    }
+
+    @Test
+    fun `diagnose file not found error`() {
+        val lines = listOf(
+            "ffmpeg version 5.1.2",
+            "/input/file.mkv: No such file or directory"
+        )
+
+        val diagnosis = ErrorDiagnostics.diagnose(lines)
+        assertEquals("Input file not found", diagnosis)
+    }
+
+    @Test
+    fun `diagnose encoder not found error`() {
+        val lines = listOf(
+            "Unknown encoder 'libx265'"
+        )
+
+        val diagnosis = ErrorDiagnostics.diagnose(lines)
+        assertEquals("Encoder not available (may need to be compiled into FFmpeg)", diagnosis)
+    }
+
+    @Test
+    fun `diagnose permission denied error`() {
+        val lines = listOf(
+            "Permission denied"
+        )
+
+        val diagnosis = ErrorDiagnostics.diagnose(lines)
+        assertEquals("Permission denied accessing file", diagnosis)
+    }
+
+    @Test
+    fun `diagnose returns null for unknown error`() {
+        val lines = listOf(
+            "Some random output",
+            "That doesn't match any pattern"
+        )
+
+        assertNull(ErrorDiagnostics.diagnose(lines))
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -35,5 +35,6 @@ plugins {
 
 include(":composeApp")
 include(":ytdlp")
+include(":ffmpeg")
 include(":network")
 include(":logging")


### PR DESCRIPTION
## Summary

Add a new FFmpeg module (`ffmpeg/`) similar to the existing `ytdlp` module, providing an async event-driven API for media conversion and analysis.

### Features
- Automatic FFmpeg/FFprobe binary download and management
- Media analysis via FFprobe (codec, resolution, duration, streams, etc.)
- Video encoding: H.264, H.265/HEVC, AV1, VP9
- Audio encoding: AAC, MP3, Opus, FLAC, AC3, and more
- Quality options: CRF, CBR, VBR with encoder presets
- Quick methods: `extractAudioMp3`, `remux`, `trim`, `encodeH264`, `encodeH265`
- Progress tracking and cancellation support
- Unit tests and demo files

### Module Structure
```
ffmpeg/
├── FfmpegWrapper.kt          # Main API
├── core/Events.kt            # ConversionEvent, InitEvent
├── core/Options.kt           # ConversionOptions, VideoOptions, AudioOptions
├── model/                    # Encoder, Bitrate, Format, MediaInfo
├── util/                     # CommandBuilder, ProgressParser, PlatformUtils
├── demos/                    # Usage examples
└── tests/                    # Unit tests
```

## Test plan
- [x] Module compiles successfully
- [x] Unit tests pass
- [x] Manual testing with real media files
- [ ] Integration with composeApp (future PR)