### PR TITLE
fix: remove menuGroup from Windows packaging config

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -150,7 +150,6 @@ compose.desktop {
 
             windows {
                 dirChooser = true
-                menuGroup = "start-menu-group"
                 iconFile.set(project.file("icons/logo.ico"))
                 shortcut = true
                 upgradeUuid = "ada57c09-11e1-4d56-9d5d-0c480f6968ec"


### PR DESCRIPTION
## Summary
- Remove `menuGroup = "start-menu-group"` from Windows packaging configuration

Fixes #48

## Test plan
- [x] Build and install MSI on Windows
- [x] Verify app appears correctly in Start Menu