### PR TITLE
fix: reset only AeroDL data instead of shared temp directory

### DIFF
--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/di/AppGraph.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/di/AppGraph.kt
@@ -5,7 +5,9 @@ package io.github.kdroidfilter.ytdlpgui.di
 import coil3.ImageLoader
 import com.kdroid.composetray.tray.api.ExperimentalTrayAppApi
 import com.kdroid.composetray.tray.api.TrayAppState
+import com.russhwolf.settings.PreferencesSettings
 import com.russhwolf.settings.Settings
+import java.util.prefs.Preferences
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
@@ -45,7 +47,10 @@ abstract class AppGraph : ViewModelGraph {
 
     @Provides
     @SingleIn(AppScope::class)
-    fun provideSettings(): Settings = Settings()
+    fun provideSettings(): Settings {
+        val prefs = Preferences.userRoot().node("io/github/kdroidfilter/aerodl")
+        return PreferencesSettings(prefs)
+    }
 
     @Provides
     @SingleIn(AppScope::class)

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/system/settings/SettingsViewModel.kt
@@ -12,6 +12,7 @@ import io.github.kdroidfilter.ytdlpgui.core.ui.MVIViewModel
 import io.github.kdroidfilter.ytdlpgui.data.DownloadHistoryRepository
 import io.github.kdroidfilter.ytdlpgui.data.SettingsRepository
 import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.databasesDir
 import io.github.vinceglb.filekit.dialogs.FileKitDialogSettings
 import io.github.vinceglb.filekit.dialogs.openDirectoryPicker
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,6 +27,7 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.binding
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import io.github.kdroidfilter.ytdlpgui.di.AppScope
+import io.github.vinceglb.filekit.path
 
 @ContributesIntoMap(AppScope::class, binding = binding<ViewModel>())
 @ViewModelKey(SettingsViewModel::class)
@@ -181,13 +183,16 @@ class SettingsViewModel(
     }
 
     private fun clearBinariesAndTemp() {
-        // Clear java temp directory
-        val tmpDir = System.getProperty("java.io.tmpdir")
+        // Clear only AeroDL's data directory (yt-dlp/FFmpeg binaries)
+        // Do NOT clear the shared java.io.tmpdir as it affects other applications
         try {
-            File(tmpDir).listFiles()?.forEach { file ->
-                try {
-                    if (file.isDirectory) file.deleteRecursively() else file.delete()
-                } catch (_: Exception) { /* ignore */ }
+            val dataDir = File(FileKit.databasesDir.path)
+            if (dataDir.exists()) {
+                dataDir.listFiles()?.forEach { file ->
+                    try {
+                        if (file.isDirectory) file.deleteRecursively() else file.delete()
+                    } catch (_: Exception) { /* ignore */ }
+                }
             }
         } catch (_: Exception) { /* ignore */ }
     }

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/main.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/main.kt
@@ -50,6 +50,8 @@ import io.github.kdroidfilter.ytdlpgui.di.LocalAppGraph
 import io.github.kdroidfilter.ytdlpgui.di.TrayAppStateHolder
 import io.github.kdroidfilter.ytdlpgui.features.system.settings.SettingsEvents
 import io.github.vinceglb.filekit.FileKit
+import io.github.vinceglb.filekit.databasesDir
+import io.github.vinceglb.filekit.path
 import kotlinx.coroutines.runBlocking
 import org.jetbrains.compose.resources.getString
 import ytdlpgui.composeapp.generated.resources.*
@@ -73,11 +75,11 @@ fun main() {
             lockIdentifier = "aerodl"
         )
 
-        if (cleanInstall) {
-            clearJavaTempDir()
-        }
-
         FileKit.init(appId = "ada57c09-11e1-4d56-9d5d-0c480f6968ec")
+
+        if (cleanInstall) {
+            clearAppData()
+        }
 
 //    Locale.setDefault(Locale("en"))
         val appGraph = remember { createGraph<AppGraph>() }
@@ -210,18 +212,21 @@ fun main() {
     }
 }
 
-fun clearJavaTempDir() {
-    val tmpDir = System.getProperty("java.io.tmpdir")
-    val dir = File(tmpDir)
-    dir.listFiles()?.forEach { file ->
-        try {
-            if (file.isDirectory) file.deleteRecursively()
-            else file.delete()
-        } catch (e: Exception) {
-            errorln { "Failed to delete ${file.absolutePath}: ${e.message}" }
+fun clearAppData() {
+    // Clear only AeroDL's data directory (yt-dlp/FFmpeg binaries)
+    // Do NOT clear the shared java.io.tmpdir as it affects other applications
+    val dataDir = File(FileKit.databasesDir.path)
+    if (dataDir.exists()) {
+        dataDir.listFiles()?.forEach { file ->
+            try {
+                if (file.isDirectory) file.deleteRecursively()
+                else file.delete()
+            } catch (e: Exception) {
+                errorln { "Failed to delete ${file.absolutePath}: ${e.message}" }
+            }
         }
     }
-    infoln { "Cache cleared: $tmpDir" }
+    infoln { "App data cleared: ${dataDir.absolutePath}" }
 }
 
 private fun clearSettings(settings: Settings) {


### PR DESCRIPTION
## Summary
- Fix reset function to only clear AeroDL's data directory (`FileKit.databasesDir`)
- Stop clearing the shared `java.io.tmpdir` which affected other applications

## Problem
When resetting AeroDL from settings, the app was clearing the entire Java temp directory (`java.io.tmpdir`), which is shared by all Java applications on the system. This caused other apps like Zayit to lose their data and require reconfiguration.

## Solution
- Modified `clearBinariesAndTemp()` in SettingsViewModel to only delete files in `FileKit.databasesDir`
- Renamed `clearJavaTempDir()` to `clearAppData()` in main.kt with the same fix
- Moved `FileKit.init()` before the clean install check so the data directory is available

Fixes kdroidFilter/Zayit#216

## Test plan
- [x] Reset AeroDL from settings
- [x] Verify Zayit data is not affected
- [x] Verify AeroDL binaries (yt-dlp, FFmpeg) are properly deleted
- [x] Verify app restarts correctly after reset