### PR TITLE
feat: use artifact transform to clean native binaries from JARs

### DIFF
--- a/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/CleanNativesTransform.kt
+++ b/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/CleanNativesTransform.kt
@@ -1,0 +1,74 @@
+package io.github.kdroidfilter.buildsrc
+
+import org.gradle.api.artifacts.transform.InputArtifact
+import org.gradle.api.artifacts.transform.TransformAction
+import org.gradle.api.artifacts.transform.TransformOutputs
+import org.gradle.api.artifacts.transform.TransformParameters
+import org.gradle.api.file.FileSystemLocation
+import org.gradle.api.provider.Provider
+import org.gradle.api.provider.SetProperty
+import org.gradle.api.tasks.Input
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+
+abstract class CleanNativesTransform : TransformAction<CleanNativesTransform.Parameters> {
+
+    interface Parameters : TransformParameters {
+        @get:Input
+        val foldersToRemove: SetProperty<String>
+    }
+
+    @get:InputArtifact
+    abstract val inputArtifact: Provider<FileSystemLocation>
+
+    override fun transform(outputs: TransformOutputs) {
+        val inputFile = inputArtifact.get().asFile
+        val foldersToRemove = parameters.foldersToRemove.get()
+
+        if (!inputFile.name.endsWith(".jar")) {
+            outputs.file(inputFile)
+            return
+        }
+
+        // Check if this JAR contains any folders we want to remove
+        val hasTargetFolders = ZipFile(inputFile).use { zip ->
+            zip.entries().asSequence().any { entry ->
+                foldersToRemove.any { folder -> entry.name.startsWith("$folder/") }
+            }
+        }
+
+        if (!hasTargetFolders) {
+            outputs.file(inputFile)
+            return
+        }
+
+        // Create cleaned JAR
+        val outputFile = outputs.file("cleaned-${inputFile.name}")
+        var removedCount = 0
+
+        ZipFile(inputFile).use { zip ->
+            ZipOutputStream(outputFile.outputStream()).use { zos ->
+                zip.entries().asSequence().forEach { entry ->
+                    val shouldRemove = foldersToRemove.any { folder ->
+                        entry.name.startsWith("$folder/")
+                    }
+
+                    if (shouldRemove) {
+                        removedCount++
+                    } else {
+                        zos.putNextEntry(ZipEntry(entry.name))
+                        if (!entry.isDirectory) {
+                            zip.getInputStream(entry).use { it.copyTo(zos) }
+                        }
+                        zos.closeEntry()
+                    }
+                }
+            }
+        }
+
+        if (removedCount > 0) {
+            println("  Cleaned ${inputFile.name}: removed $removedCount native entries")
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/NativeCleanupTransformHelper.kt
+++ b/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/NativeCleanupTransformHelper.kt
@@ -1,0 +1,95 @@
+package io.github.kdroidfilter.buildsrc
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.type.ArtifactTypeDefinition
+
+object NativeCleanupTransformHelper {
+    private val hostOs: String = System.getProperty("os.name") ?: error("Unable to detect OS")
+    private val hostArch: String = System.getProperty("os.arch") ?: error("Unable to detect architecture")
+
+    // Convention JNA (com/sun/jna/os-arch)
+    private const val JNA_PREFIX = "com/sun/jna"
+
+    private val jnaFolderToKeep: String = when {
+        hostOs == "Mac OS X" && hostArch == "aarch64" -> "$JNA_PREFIX/darwin-aarch64"
+        hostOs == "Mac OS X" -> "$JNA_PREFIX/darwin-x86-64"
+        hostOs.startsWith("Windows") && hostArch == "amd64" -> "$JNA_PREFIX/win32-x86-64"
+        hostOs.startsWith("Windows") && hostArch == "aarch64" -> "$JNA_PREFIX/win32-aarch64"
+        hostOs.startsWith("Windows") -> "$JNA_PREFIX/win32-x86"
+        hostOs == "Linux" && hostArch == "aarch64" -> "$JNA_PREFIX/linux-aarch64"
+        hostOs == "Linux" -> "$JNA_PREFIX/linux-x86-64"
+        else -> error("Unsupported platform: $hostOs / $hostArch")
+    }
+
+    private val allJnaFolders: Set<String> = setOf(
+        "$JNA_PREFIX/aix-ppc", "$JNA_PREFIX/aix-ppc64",
+        "$JNA_PREFIX/darwin-aarch64", "$JNA_PREFIX/darwin-x86-64",
+        "$JNA_PREFIX/dragonflybsd-x86-64",
+        "$JNA_PREFIX/freebsd-aarch64", "$JNA_PREFIX/freebsd-x86", "$JNA_PREFIX/freebsd-x86-64",
+        "$JNA_PREFIX/linux-aarch64", "$JNA_PREFIX/linux-arm", "$JNA_PREFIX/linux-armel",
+        "$JNA_PREFIX/linux-loongarch64", "$JNA_PREFIX/linux-mips64el",
+        "$JNA_PREFIX/linux-ppc", "$JNA_PREFIX/linux-ppc64le",
+        "$JNA_PREFIX/linux-riscv64", "$JNA_PREFIX/linux-s390x",
+        "$JNA_PREFIX/linux-x86", "$JNA_PREFIX/linux-x86-64",
+        "$JNA_PREFIX/openbsd-x86", "$JNA_PREFIX/openbsd-x86-64",
+        "$JNA_PREFIX/sunos-sparc", "$JNA_PREFIX/sunos-sparcv9",
+        "$JNA_PREFIX/sunos-x86", "$JNA_PREFIX/sunos-x86-64",
+        "$JNA_PREFIX/win32-aarch64", "$JNA_PREFIX/win32-x86", "$JNA_PREFIX/win32-x86-64"
+    )
+
+    // Convention sqlite-jdbc (org/sqlite/native/OS/arch)
+    private const val SQLITE_PREFIX = "org/sqlite/native"
+
+    private val sqliteJdbcFolderToKeep: String = when {
+        hostOs == "Mac OS X" && hostArch == "aarch64" -> "$SQLITE_PREFIX/Mac/aarch64"
+        hostOs == "Mac OS X" -> "$SQLITE_PREFIX/Mac/x86_64"
+        hostOs.startsWith("Windows") && hostArch == "amd64" -> "$SQLITE_PREFIX/Windows/x86_64"
+        hostOs.startsWith("Windows") && hostArch == "aarch64" -> "$SQLITE_PREFIX/Windows/aarch64"
+        hostOs.startsWith("Windows") -> "$SQLITE_PREFIX/Windows/x86"
+        hostOs == "Linux" && hostArch == "aarch64" -> "$SQLITE_PREFIX/Linux/aarch64"
+        hostOs == "Linux" -> "$SQLITE_PREFIX/Linux/x86_64"
+        else -> error("Unsupported platform: $hostOs / $hostArch")
+    }
+
+    private val allSqliteJdbcFolders: Set<String> = setOf(
+        "$SQLITE_PREFIX/FreeBSD/aarch64", "$SQLITE_PREFIX/FreeBSD/x86", "$SQLITE_PREFIX/FreeBSD/x86_64",
+        "$SQLITE_PREFIX/Linux/aarch64", "$SQLITE_PREFIX/Linux/arm", "$SQLITE_PREFIX/Linux/armv6",
+        "$SQLITE_PREFIX/Linux/armv7", "$SQLITE_PREFIX/Linux/ppc64", "$SQLITE_PREFIX/Linux/riscv64",
+        "$SQLITE_PREFIX/Linux/x86", "$SQLITE_PREFIX/Linux/x86_64",
+        "$SQLITE_PREFIX/Linux-Android/aarch64", "$SQLITE_PREFIX/Linux-Android/arm",
+        "$SQLITE_PREFIX/Linux-Android/x86", "$SQLITE_PREFIX/Linux-Android/x86_64",
+        "$SQLITE_PREFIX/Linux-Musl/aarch64", "$SQLITE_PREFIX/Linux-Musl/x86", "$SQLITE_PREFIX/Linux-Musl/x86_64",
+        "$SQLITE_PREFIX/Mac/aarch64", "$SQLITE_PREFIX/Mac/x86_64",
+        "$SQLITE_PREFIX/Windows/aarch64", "$SQLITE_PREFIX/Windows/armv7",
+        "$SQLITE_PREFIX/Windows/x86", "$SQLITE_PREFIX/Windows/x86_64"
+    )
+
+    val foldersToRemove: Set<String> = (allJnaFolders - jnaFolderToKeep) +
+        (allSqliteJdbcFolders - sqliteJdbcFolderToKeep)
+
+    fun registerTransform(project: Project) {
+        val foldersToRemoveSet = foldersToRemove
+
+        // Register the transform: jar -> cleaned-jar
+        project.dependencies.registerTransform(CleanNativesTransform::class.java) {
+            from.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "jar")
+            to.attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "cleaned-jar")
+            parameters {
+                foldersToRemove.set(foldersToRemoveSet)
+            }
+        }
+
+        // Request cleaned-jar for runtime classpaths as they are created
+        project.configurations.whenObjectAdded {
+            if (name.contains("RuntimeClasspath", ignoreCase = true)) {
+                attributes {
+                    attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "cleaned-jar")
+                }
+            }
+        }
+
+        println("Native cleanup transform registered for $hostOs $hostArch")
+        println("  Keeping: $jnaFolderToKeep, $sqliteJdbcFolderToKeep")
+        println("  Removing ${foldersToRemoveSet.size} platform-specific native folders")
+    }
+}


### PR DESCRIPTION
## Summary
- Replace task-based JAR cleanup with Gradle artifact transform for more reliable native binary removal
- The transform cleans JNA and SQLite-JDBC native folders for non-target platforms during dependency resolution
- Ensures the final MSI/DMG contains only platform-specific binaries, reducing package size

## Changes
- Added `CleanNativesTransform.kt` - Gradle artifact transform that removes unwanted native folders from JARs
- Added `NativeCleanupTransformHelper.kt` - Helper to register the transform and configure runtime classpaths
- Updated `composeApp/build.gradle.kts` to use the new transform approach

## Test plan
- [x] Build MSI with `./gradlew :composeApp:packageReleaseMsi`
- [x] Verify installed app contains only Windows-specific native binaries
- [x] Verify app launches correctly after installation