### PR TITLE
fix: use configureEach instead of whenObjectAdded for runtime classpaths

### DIFF
--- a/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/NativeCleanupTransformHelper.kt
+++ b/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/NativeCleanupTransformHelper.kt
@@ -79,8 +79,8 @@ object NativeCleanupTransformHelper {
             }
         }
 
-        // Request cleaned-jar for runtime classpaths as they are created
-        project.configurations.whenObjectAdded {
+        // Request cleaned-jar for all runtime classpaths (existing and future)
+        project.configurations.configureEach {
             if (name.contains("RuntimeClasspath", ignoreCase = true)) {
                 attributes {
                     attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, "cleaned-jar")


### PR DESCRIPTION
## Summary
- Fix artifact transform not being applied consistently across all environments
- `whenObjectAdded` only captures configurations added after registration
- `configureEach` captures both existing and future configurations

## Test plan
- [ ] Verify MSI size is reduced after build