### PR TITLE
fix: display MP4 label for conversions in history

### DIFF
--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/manager/DownloadScreen.kt
@@ -306,7 +306,12 @@ private fun HistoryThumbnail(h: HistoryItem) {
                 )
             }
 
-            val overlay = if (h.isSplit) "Split" else if (h.isAudio) "MP3" else h.presetHeight?.let { "${it}P" } ?: ""
+            val overlay = when {
+                h.isSplit -> "Split"
+                h.isAudio -> "MP3"
+                isConversion -> "MP4"
+                else -> h.presetHeight?.let { "${it}P" } ?: ""
+            }
             Text(
                 overlay,
                 textAlign = TextAlign.Center,


### PR DESCRIPTION
## Summary
- Fix missing label for MP4 conversions in download history
- MP3 conversions correctly showed "MP3" but MP4 conversions showed empty label
- Now properly displays "MP4" for video conversions

## Root cause
For conversions, `presetHeight` is always `null` (only used for downloads), so the label fell through to empty string.