### PR TITLE
feat(download): add trim/cut and hardware acceleration support

### DIFF
--- a/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-fr/strings.xml
@@ -3,7 +3,7 @@
     <!-- Navigation -->
     <string name="quit">Quitter</string>
     <string name="home">Accueil</string>
-    <string name="download">Tâches</string>
+    <string name="tasks">Tâches</string>
     <string name="about">À propos</string>
     <string name="settings">Paramètres</string>
 
@@ -114,6 +114,7 @@
     <string name="settings_download_dir_pick_title">Sélectionner le dossier de téléchargement</string>
     <string name="settings_select">Sélectionner…</string>
 
+    <string name="download_button">Télécharger</string>
     <string name="download_audio">Télécharger l'audio</string>
     <!-- Ces chaînes appartiennent à l'écran Download (Download screen) -->
     <string name="download_type_video">Vidéo</string>

--- a/composeApp/src/jvmMain/composeResources/values-he/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values-he/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <!-- Navigation -->
     <string name="home">דף הבית</string>
-    <string name="download">משימות</string>
+    <string name="tasks">משימות</string>
     <string name="about">אודות</string>
     <string name="settings">הגדרות</string>
 

--- a/composeApp/src/jvmMain/composeResources/values/strings.xml
+++ b/composeApp/src/jvmMain/composeResources/values/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <!-- Navigation -->
     <string name="home">Home</string>
-    <string name="download">Tasks</string>
+    <string name="tasks">Tasks</string>
     <string name="split_chapters">Split chapters</string>
     <string name="split_badge">Split</string>
     <string name="remove_sponsors">Remove sponsors (SponsorBlock)</string>
@@ -116,6 +116,7 @@
     <string name="settings_download_dir_pick_title">Select download folder</string>
     <string name="settings_select">Select…</string>
 
+    <string name="download_button">Download</string>
     <string name="download_audio">Download audio</string>
     <!-- Ces chaînes appartiennent à l'écran Download (Download screen) -->
     <string name="download_type_video">Video</string>

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/design/components/TrimSlider.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/design/components/TrimSlider.kt
@@ -1,0 +1,100 @@
+package io.github.kdroidfilter.ytdlpgui.core.design.components
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.RangeSlider
+import androidx.compose.material3.SliderDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import io.github.composefluent.FluentTheme
+import io.github.composefluent.component.Text
+import org.jetbrains.compose.resources.stringResource
+import ytdlpgui.composeapp.generated.resources.Res
+import ytdlpgui.composeapp.generated.resources.converter_trim
+import ytdlpgui.composeapp.generated.resources.converter_trim_duration
+
+/**
+ * Reusable trim/cut slider component for selecting a time range.
+ * Used in both Converter and Download screens.
+ */
+@Composable
+fun TrimSlider(
+    trimStartMs: Long,
+    trimEndMs: Long,
+    totalDurationMs: Long,
+    isTrimmed: Boolean,
+    onTrimRangeChange: (startMs: Long, endMs: Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier) {
+        Text(
+            text = stringResource(Res.string.converter_trim),
+            style = FluentTheme.typography.bodyStrong,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Spacer(Modifier.height(8.dp))
+
+        // Time labels
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Text(
+                text = formatDuration(trimStartMs),
+                style = FluentTheme.typography.caption,
+                color = FluentTheme.colors.text.text.secondary
+            )
+            Text(
+                text = formatDuration(trimEndMs),
+                style = FluentTheme.typography.caption,
+                color = FluentTheme.colors.text.text.secondary
+            )
+        }
+
+        // RangeSlider
+        RangeSlider(
+            value = trimStartMs.toFloat()..trimEndMs.toFloat(),
+            onValueChange = { range ->
+                onTrimRangeChange(range.start.toLong(), range.endInclusive.toLong())
+            },
+            valueRange = 0f..totalDurationMs.toFloat(),
+            modifier = Modifier.fillMaxWidth(),
+            colors = SliderDefaults.colors(
+                thumbColor = FluentTheme.colors.fillAccent.default,
+                activeTrackColor = FluentTheme.colors.fillAccent.default,
+                inactiveTrackColor = FluentTheme.colors.stroke.control.default
+            )
+        )
+
+        // Duration info
+        if (isTrimmed) {
+            Text(
+                text = stringResource(
+                    Res.string.converter_trim_duration,
+                    formatDuration(trimEndMs - trimStartMs)
+                ),
+                style = FluentTheme.typography.caption,
+                color = FluentTheme.colors.text.text.secondary,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+/**
+ * Formats milliseconds to a human-readable duration string (H:MM:SS or M:SS).
+ */
+fun formatDuration(millis: Long): String {
+    val totalSeconds = millis / 1000
+    val hours = totalSeconds / 3600
+    val minutes = (totalSeconds % 3600) / 60
+    val seconds = totalSeconds % 60
+
+    return if (hours > 0) {
+        String.format("%d:%02d:%02d", hours, minutes, seconds)
+    } else {
+        String.format("%d:%02d", minutes, seconds)
+    }
+}

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/ui/Header.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/core/ui/Header.kt
@@ -83,7 +83,7 @@ fun MainNavigationHeader(
                 val (titleRes, icon, destForIndex) = when (index) {
                     0 -> Triple(Res.string.home, Icons.Default.Home, Destination.MainNavigation.Home as Destination)
                     else -> Triple(
-                        Res.string.download,
+                        Res.string.tasks,
                         Icons.Default.History,
                         Destination.MainNavigation.Downloader as Destination
                     )

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/converter/ConverterOptionsScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/converter/ConverterOptionsScreen.kt
@@ -8,8 +8,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollbarAdapter
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.RangeSlider
-import androidx.compose.material3.SliderDefaults
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -24,6 +22,8 @@ import io.github.composefluent.component.*
 import io.github.composefluent.icons.Icons
 import io.github.composefluent.icons.regular.MusicNote1
 import io.github.composefluent.icons.regular.Video
+import io.github.kdroidfilter.ytdlpgui.core.design.components.TrimSlider
+import io.github.kdroidfilter.ytdlpgui.core.design.components.formatDuration
 import io.github.kdroidfilter.ytdlpgui.core.navigation.Destination
 import io.github.kdroidfilter.ytdlpgui.di.LocalAppGraph
 import org.jetbrains.compose.resources.stringResource
@@ -171,7 +171,15 @@ private fun ConversionOptionsContent(
                 // Trim slider
                 if (state.showTrimSlider) {
                     item {
-                        TrimSlider(state, onEvent)
+                        TrimSlider(
+                            trimStartMs = state.trimStartMs,
+                            trimEndMs = state.trimEndMs,
+                            totalDurationMs = state.totalDurationMs,
+                            isTrimmed = state.isTrimmed,
+                            onTrimRangeChange = { startMs, endMs ->
+                                onEvent(ConverterOptionsEvents.SetTrimRange(startMs, endMs))
+                            }
+                        )
                     }
                 }
 
@@ -356,82 +364,5 @@ private fun AudioQualitySelector(
                 }
             }
         }
-    }
-}
-
-@Composable
-private fun TrimSlider(
-    state: ConverterOptionsState,
-    onEvent: (ConverterOptionsEvents) -> Unit
-) {
-    Column {
-        Text(
-            text = stringResource(Res.string.converter_trim),
-            style = FluentTheme.typography.bodyStrong,
-            modifier = Modifier.fillMaxWidth()
-        )
-        Spacer(Modifier.height(8.dp))
-
-        // Time labels
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
-            Text(
-                text = formatDuration(state.trimStartMs),
-                style = FluentTheme.typography.caption,
-                color = FluentTheme.colors.text.text.secondary
-            )
-            Text(
-                text = formatDuration(state.trimEndMs),
-                style = FluentTheme.typography.caption,
-                color = FluentTheme.colors.text.text.secondary
-            )
-        }
-
-        // RangeSlider
-        RangeSlider(
-            value = state.trimStartMs.toFloat()..state.trimEndMs.toFloat(),
-            onValueChange = { range ->
-                onEvent(ConverterOptionsEvents.SetTrimRange(
-                    startMs = range.start.toLong(),
-                    endMs = range.endInclusive.toLong()
-                ))
-            },
-            valueRange = 0f..state.totalDurationMs.toFloat(),
-            modifier = Modifier.fillMaxWidth(),
-            colors = SliderDefaults.colors(
-                thumbColor = FluentTheme.colors.fillAccent.default,
-                activeTrackColor = FluentTheme.colors.fillAccent.default,
-                inactiveTrackColor = FluentTheme.colors.stroke.control.default
-            )
-        )
-
-        // Duration info
-        if (state.isTrimmed) {
-            Text(
-                text = stringResource(
-                    Res.string.converter_trim_duration,
-                    formatDuration(state.trimEndMs - state.trimStartMs)
-                ),
-                style = FluentTheme.typography.caption,
-                color = FluentTheme.colors.text.text.secondary,
-                modifier = Modifier.fillMaxWidth(),
-                textAlign = TextAlign.Center
-            )
-        }
-    }
-}
-
-private fun formatDuration(millis: Long): String {
-    val totalSeconds = millis / 1000
-    val hours = totalSeconds / 3600
-    val minutes = (totalSeconds % 3600) / 60
-    val seconds = totalSeconds % 60
-
-    return if (hours > 0) {
-        String.format("%d:%02d:%02d", hours, minutes, seconds)
-    } else {
-        String.format("%d:%02d", minutes, seconds)
     }
 }

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadEvents.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadEvents.kt
@@ -10,6 +10,8 @@ sealed class SingleDownloadEvents {
     data object ClearSubtitles : SingleDownloadEvents()
     data class SetSplitChapters(val enabled: Boolean) : SingleDownloadEvents()
     data class SetRemoveSponsors(val enabled: Boolean) : SingleDownloadEvents()
+    /** Sets the trim range for the download (in milliseconds) */
+    data class SetTrimRange(val startMs: Long, val endMs: Long) : SingleDownloadEvents()
     data object StartDownload : SingleDownloadEvents()
     data object StartAudioDownload : SingleDownloadEvents()
     data object StartSplitChaptersDownload : SingleDownloadEvents()

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadScreen.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadScreen.kt
@@ -57,6 +57,7 @@ import ytdlpgui.composeapp.generated.resources.*
 import io.github.kdroidfilter.ytdlpgui.di.LocalAppGraph
 import io.github.kdroidfilter.ytdlpgui.core.design.components.EllipsizedTextWithTooltip
 import io.github.kdroidfilter.ytdlpgui.core.design.components.Switcher
+import io.github.kdroidfilter.ytdlpgui.core.design.components.TrimSlider
 import java.time.Duration
 import java.util.*
 
@@ -116,12 +117,19 @@ fun SingleDownloadView(
         splitChapters = state.splitChapters,
         hasSponsorSegments = state.hasSponsorSegments,
         removeSponsors = state.removeSponsors,
+        // Trim state
+        trimStartMs = state.trimStartMs,
+        trimEndMs = state.trimEndMs,
+        totalDurationMs = state.totalDurationMs,
+        showTrimSlider = state.showTrimSlider,
+        isTrimmed = state.isTrimmed,
         onSelectPreset = { onEvent(SingleDownloadEvents.SelectPreset(it)) },
         onSelectAudioQualityPreset = { onEvent(SingleDownloadEvents.SelectAudioQualityPreset(it)) },
         onToggleSubtitle = { onEvent(SingleDownloadEvents.ToggleSubtitle(it)) },
         onClearSubtitles = { onEvent(SingleDownloadEvents.ClearSubtitles) },
         onSetSplitChapters = { onEvent(SingleDownloadEvents.SetSplitChapters(it)) },
         onSetRemoveSponsors = { onEvent(SingleDownloadEvents.SetRemoveSponsors(it)) },
+        onSetTrimRange = { start, end -> onEvent(SingleDownloadEvents.SetTrimRange(start, end)) },
         onStartDownload = { onEvent(SingleDownloadEvents.StartDownload) },
         onStartAudioDownload = { onEvent(SingleDownloadEvents.StartAudioDownload) }
     )
@@ -170,12 +178,19 @@ private fun SingleVideoDownloadView(
     splitChapters: Boolean,
     hasSponsorSegments: Boolean,
     removeSponsors: Boolean,
+    // Trim state
+    trimStartMs: Long,
+    trimEndMs: Long,
+    totalDurationMs: Long,
+    showTrimSlider: Boolean,
+    isTrimmed: Boolean,
     onSelectPreset: (YtDlpWrapper.Preset) -> Unit,
     onSelectAudioQualityPreset: (YtDlpWrapper.AudioQualityPreset) -> Unit,
     onToggleSubtitle: (String) -> Unit,
     onClearSubtitles: () -> Unit,
     onSetSplitChapters: (Boolean) -> Unit,
     onSetRemoveSponsors: (Boolean) -> Unit,
+    onSetTrimRange: (Long, Long) -> Unit,
     onStartDownload: () -> Unit,
     onStartAudioDownload: () -> Unit
 ) {
@@ -362,6 +377,18 @@ private fun SingleVideoDownloadView(
                         )
                         Spacer(Modifier.height(8.dp))
                     }
+
+                    // Trim slider (video mode, when not using split-chapters)
+                    if (showTrimSlider && !splitChapters) {
+                        TrimSlider(
+                            trimStartMs = trimStartMs,
+                            trimEndMs = trimEndMs,
+                            totalDurationMs = totalDurationMs,
+                            isTrimmed = isTrimmed,
+                            onTrimRangeChange = onSetTrimRange
+                        )
+                        Spacer(Modifier.height(16.dp))
+                    }
                 }
 
                 // Afficher le sélecteur de qualité audio si "Audio" est sélectionné
@@ -437,6 +464,18 @@ private fun SingleVideoDownloadView(
                             }
                         )
                     }
+
+                    // Trim slider (audio mode, when not using split-chapters)
+                    if (showTrimSlider && !splitChapters) {
+                        Spacer(Modifier.height(16.dp))
+                        TrimSlider(
+                            trimStartMs = trimStartMs,
+                            trimEndMs = trimEndMs,
+                            totalDurationMs = totalDurationMs,
+                            isTrimmed = isTrimmed,
+                            onTrimRangeChange = onSetTrimRange
+                        )
+                    }
                 }
 
                 // Bouton de téléchargement centré
@@ -447,7 +486,7 @@ private fun SingleVideoDownloadView(
                 ) {
                     AccentButton(onClick = if (selectedFormatIndex == 0) onStartDownload else onStartAudioDownload) {
                         Icon(Icons.Default.ArrowDownload, null)
-                        Text(stringResource(Res.string.download))
+                        Text(stringResource(Res.string.download_button))
                     }
 
                     // Split-chapters now controlled by a checkbox above

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadState.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadState.kt
@@ -25,8 +25,19 @@ data class SingleDownloadState(
     val splitChapters: Boolean = false,
     val hasSponsorSegments: Boolean = false,
     val removeSponsors: Boolean = false,
-    val navigationState: SingleDownloadNavigationState = SingleDownloadNavigationState.None
+    val navigationState: SingleDownloadNavigationState = SingleDownloadNavigationState.None,
+    // Trim/cut state
+    val trimStartMs: Long = 0L,
+    val trimEndMs: Long = 0L,
+    val totalDurationMs: Long = 0L
 ) {
+    /** True if duration is known and trim slider can be shown */
+    val showTrimSlider: Boolean
+        get() = totalDurationMs > 0L
+
+    /** True if user has modified the default range (i.e., trimmed the video) */
+    val isTrimmed: Boolean
+        get() = trimStartMs > 0L || (trimEndMs > 0L && trimEndMs < totalDurationMs)
     companion object {
         val loadingState = SingleDownloadState(
             isLoading = true

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/download/single/SingleDownloadViewModel.kt
@@ -6,6 +6,7 @@ import androidx.navigation.toRoute
 import io.github.kdroidfilter.ytdlp.YtDlpWrapper
 import io.github.kdroidfilter.ytdlp.model.SubtitleInfo
 import io.github.kdroidfilter.ytdlp.model.VideoInfo
+import io.github.kdroidfilter.ytdlp.core.DownloadSection
 import io.github.kdroidfilter.ytdlpgui.core.domain.manager.DownloadManager
 import io.github.kdroidfilter.ytdlpgui.core.navigation.Destination
 import io.github.kdroidfilter.ytdlpgui.core.ui.MVIViewModel
@@ -72,6 +73,16 @@ class SingleDownloadViewModel @AssistedInject constructor(
     private val _removeSponsors = MutableStateFlow(false)
     val removeSponsors = _removeSponsors.asStateFlow()
 
+    // Trim/cut state flows
+    private val _trimStartMs = MutableStateFlow(0L)
+    val trimStartMs = _trimStartMs.asStateFlow()
+
+    private val _trimEndMs = MutableStateFlow(0L)
+    val trimEndMs = _trimEndMs.asStateFlow()
+
+    private val _totalDurationMs = MutableStateFlow(0L)
+    val totalDurationMs = _totalDurationMs.asStateFlow()
+
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage = _errorMessage.asStateFlow()
 
@@ -93,6 +104,9 @@ class SingleDownloadViewModel @AssistedInject constructor(
         hasSponsorSegments,
         removeSponsors,
         navigationState,
+        trimStartMs,
+        trimEndMs,
+        totalDurationMs,
     ) { values: Array<Any?> ->
         val loading = values[0] as Boolean
         val error = values[1] as String?
@@ -111,6 +125,9 @@ class SingleDownloadViewModel @AssistedInject constructor(
         val sponsorAvail = values[10] as Boolean
         val rmSponsor = values[11] as Boolean
         val navState = values[12] as SingleDownloadNavigationState
+        val trimStart = values[13] as Long
+        val trimEnd = values[14] as Long
+        val totalDuration = values[15] as Long
         SingleDownloadState(
             isLoading = loading,
             errorMessage = error,
@@ -125,6 +142,9 @@ class SingleDownloadViewModel @AssistedInject constructor(
             hasSponsorSegments = sponsorAvail,
             removeSponsors = rmSponsor,
             navigationState = navState,
+            trimStartMs = trimStart,
+            trimEndMs = trimEnd,
+            totalDurationMs = totalDuration,
         )
     }.stateIn(
         scope = viewModelScope,
@@ -168,6 +188,15 @@ class SingleDownloadViewModel @AssistedInject constructor(
                     // Audio quality presets - all available
                     _availableAudioQualityPresets.value = YtDlpWrapper.AudioQualityPreset.entries
                     _selectedAudioQualityPreset.value = YtDlpWrapper.AudioQualityPreset.HIGH
+
+                    // Initialize trim state from video duration
+                    info.duration?.let { duration ->
+                        val durationMs = duration.toMillis()
+                        _totalDurationMs.value = durationMs
+                        _trimStartMs.value = 0L
+                        _trimEndMs.value = durationMs
+                        infoln { "[SingleDownloadViewModel] Trim initialized: 0 - ${durationMs}ms (${duration.seconds}s)" }
+                    }
 
                     _isLoading.value = false
                 }
@@ -220,9 +249,19 @@ class SingleDownloadViewModel @AssistedInject constructor(
                 infoln { "[SingleDownloadViewModel] Remove sponsors set to: ${event.enabled}" }
                 _removeSponsors.value = event.enabled
             }
+            is SingleDownloadEvents.SetTrimRange -> {
+                val totalMs = _totalDurationMs.value
+                val newStart = event.startMs.coerceIn(0L, totalMs)
+                val newEnd = event.endMs.coerceIn(newStart, totalMs)
+                _trimStartMs.value = newStart
+                _trimEndMs.value = newEnd
+                infoln { "[SingleDownloadViewModel] Trim range set: ${newStart}ms - ${newEnd}ms" }
+            }
             SingleDownloadEvents.StartDownload -> {
                 val preset = selectedPreset.value
                 val subtitles = selectedSubtitles.value
+                // Build download section if trimmed (trim is incompatible with split-chapters)
+                val downloadSection = buildDownloadSectionIfTrimmed()
                 if (_splitChapters.value) {
                     if (subtitles.isNotEmpty()) {
                         infoln { "[SingleDownloadViewModel] Starting split-chapters download with subtitles: ${subtitles.joinToString(",")}, preset: ${preset?.height}p" }
@@ -245,29 +284,32 @@ class SingleDownloadViewModel @AssistedInject constructor(
                     }
                 } else {
                     if (subtitles.isNotEmpty()) {
-                        infoln { "[SingleDownloadViewModel] Starting download with subtitles: ${subtitles.joinToString(",")}, preset: ${preset?.height}p" }
+                        infoln { "[SingleDownloadViewModel] Starting download with subtitles: ${subtitles.joinToString(",")}, preset: ${preset?.height}p, trimmed: ${downloadSection != null}" }
                         downloadManager.startWithSubtitles(
                             url = videoUrl,
                             videoInfo = videoInfo.value,
                             preset = preset,
                             languages = subtitles,
-                            sponsorBlock = _removeSponsors.value
+                            sponsorBlock = _removeSponsors.value,
+                            downloadSection = downloadSection
                         )
                     } else {
-                        infoln { "[SingleDownloadViewModel] Starting download without subtitles, preset: ${preset?.height}p" }
-                        downloadManager.start(videoUrl, videoInfo.value, preset, sponsorBlock = _removeSponsors.value)
+                        infoln { "[SingleDownloadViewModel] Starting download without subtitles, preset: ${preset?.height}p, trimmed: ${downloadSection != null}" }
+                        downloadManager.start(videoUrl, videoInfo.value, preset, sponsorBlock = _removeSponsors.value, downloadSection = downloadSection)
                     }
                 }
                 _navigationState.value = SingleDownloadNavigationState.NavigateToDownloader
             }
             SingleDownloadEvents.StartAudioDownload -> {
                 val audioQuality = selectedAudioQualityPreset.value
+                // Build download section if trimmed (trim is incompatible with split-chapters)
+                val downloadSection = buildDownloadSectionIfTrimmed()
                 if (_splitChapters.value) {
                     infoln { "[SingleDownloadViewModel] Starting audio split-chapters download with quality: ${audioQuality?.name}" }
                     downloadManager.startAudioSplitChapters(videoUrl, videoInfo.value, audioQuality, sponsorBlock = _removeSponsors.value)
                 } else {
-                    infoln { "[SingleDownloadViewModel] Starting audio download with quality: ${audioQuality?.name}" }
-                    downloadManager.startAudio(videoUrl, videoInfo.value, audioQuality, sponsorBlock = _removeSponsors.value)
+                    infoln { "[SingleDownloadViewModel] Starting audio download with quality: ${audioQuality?.name}, trimmed: ${downloadSection != null}" }
+                    downloadManager.startAudio(videoUrl, videoInfo.value, audioQuality, sponsorBlock = _removeSponsors.value, downloadSection = downloadSection)
                 }
                 _navigationState.value = SingleDownloadNavigationState.NavigateToDownloader
             }
@@ -321,5 +363,26 @@ class SingleDownloadViewModel @AssistedInject constructor(
                 _navigationState.value = SingleDownloadNavigationState.None
             }
         }
+    }
+
+    /**
+     * Creates a DownloadSection if the user has trimmed the video/audio.
+     * Returns null if no trimming was done (full duration selected).
+     */
+    private fun buildDownloadSectionIfTrimmed(): DownloadSection? {
+        val totalMs = _totalDurationMs.value
+        if (totalMs <= 0L) return null
+
+        val startMs = _trimStartMs.value
+        val endMs = _trimEndMs.value
+
+        // Check if trimmed (not full duration)
+        val isTrimmed = startMs > 0L || endMs < totalMs
+        if (!isTrimmed) return null
+
+        return DownloadSection(
+            startSeconds = startMs / 1000.0,
+            endSeconds = endMs / 1000.0
+        )
     }
 }

--- a/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/core/Options.kt
+++ b/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/core/Options.kt
@@ -3,6 +3,34 @@ package io.github.kdroidfilter.ytdlp.core
 import java.time.Duration
 
 /**
+ * Defines a time range to download from a video.
+ * Uses yt-dlp's --download-sections format.
+ *
+ * @property startSeconds The start time in seconds
+ * @property endSeconds The end time in seconds
+ */
+data class DownloadSection(
+    val startSeconds: Double,
+    val endSeconds: Double
+) {
+    /**
+     * Formats the section for yt-dlp's --download-sections argument.
+     * Format: "*START-END" where times are in HH:MM:SS format.
+     */
+    fun toYtDlpFormat(): String {
+        return "*${formatTime(startSeconds)}-${formatTime(endSeconds)}"
+    }
+
+    private fun formatTime(seconds: Double): String {
+        val totalSec = seconds.toLong()
+        val h = totalSec / 3600
+        val m = (totalSec % 3600) / 60
+        val s = totalSec % 60
+        return if (h > 0) "%d:%02d:%02d".format(h, m, s) else "%d:%02d".format(m, s)
+    }
+}
+
+/**
  * Configuration for subtitle downloading
  */
 data class SubtitleOptions(
@@ -30,6 +58,8 @@ data class SubtitleOptions(
  * @property sponsorBlockRemove If true, removes SponsorBlock segments (default categories).
  * @property concurrentFragments Number of threads for downloading m3u8/mpd fragments in parallel (1-5). 1 = disabled.
  * @property proxy Proxy URL to use for the download (e.g., "http://127.0.0.1:8080", "socks5://127.0.0.1:1080"). Null to disable.
+ * @property downloadSection Time range to download (trim/cut). Null to download the entire video.
+ * @property useHardwareAcceleration If true, uses hardware acceleration for re-encoding when available.
  */
 data class Options(
     val format: String? = null,
@@ -43,5 +73,7 @@ data class Options(
     val subtitles: SubtitleOptions? = null,
     val sponsorBlockRemove: Boolean = false,
     val concurrentFragments: Int = 1,
-    val proxy: String? = null
+    val proxy: String? = null,
+    val downloadSection: DownloadSection? = null,
+    val useHardwareAcceleration: Boolean = true
 )

--- a/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/util/HwAccelDetector.kt
+++ b/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/util/HwAccelDetector.kt
@@ -1,0 +1,116 @@
+package io.github.kdroidfilter.ytdlp.util
+
+import io.github.kdroidfilter.logging.infoln
+import java.util.concurrent.TimeUnit
+
+/**
+ * Detects available FFmpeg hardware encoders for use with yt-dlp post-processing.
+ * Supports NVENC (NVIDIA), QSV (Intel), AMF (AMD), VideoToolbox (macOS), and VAAPI (Linux).
+ */
+object HwAccelDetector {
+
+    enum class Platform { WINDOWS, LINUX, MACOS }
+
+    @Volatile
+    private var cachedH264Encoder: String? = null
+
+    @Volatile
+    private var detectionAttempted: Boolean = false
+
+    val currentPlatform: Platform by lazy {
+        val os = System.getProperty("os.name").lowercase()
+        when {
+            os.contains("win") -> Platform.WINDOWS
+            os.contains("mac") || os.contains("darwin") -> Platform.MACOS
+            else -> Platform.LINUX
+        }
+    }
+
+    /**
+     * Gets the best available H.264 hardware encoder for yt-dlp post-processing.
+     * Returns null if no hardware encoder is available (will use software encoding).
+     *
+     * @param ffmpegPath Path to the FFmpeg executable
+     * @return The encoder name (e.g., "h264_nvenc") or null if none available
+     */
+    fun getBestH264Encoder(ffmpegPath: String): String? {
+        if (detectionAttempted) return cachedH264Encoder
+
+        synchronized(this) {
+            if (detectionAttempted) return cachedH264Encoder
+
+            val available = detectAvailableEncoders(ffmpegPath)
+
+            val preferred = when (currentPlatform) {
+                Platform.WINDOWS -> listOf("h264_nvenc", "h264_qsv", "h264_amf")
+                Platform.MACOS -> listOf("h264_videotoolbox")
+                Platform.LINUX -> listOf("h264_nvenc", "h264_vaapi")
+            }
+
+            cachedH264Encoder = preferred.firstOrNull { it in available }
+            detectionAttempted = true
+
+            if (cachedH264Encoder != null) {
+                infoln { "[HwAccelDetector] Detected hardware encoder: $cachedH264Encoder" }
+            } else {
+                infoln { "[HwAccelDetector] No hardware encoder available, will use software encoding" }
+            }
+
+            return cachedH264Encoder
+        }
+    }
+
+    private fun detectAvailableEncoders(ffmpegPath: String): List<String> {
+        return try {
+            val process = ProcessBuilder(ffmpegPath, "-hide_banner", "-encoders")
+                .redirectErrorStream(true)
+                .start()
+
+            val output = process.inputStream.bufferedReader().readText()
+            val exited = process.waitFor(10, TimeUnit.SECONDS)
+
+            if (!exited) {
+                process.destroyForcibly()
+                return emptyList()
+            }
+
+            output.lines()
+                .filter { it.trim().startsWith("V") }
+                .mapNotNull { line -> line.trim().split(Regex("\\s+")).getOrNull(1) }
+        } catch (e: Exception) {
+            infoln { "[HwAccelDetector] Failed to detect encoders: ${e.message}" }
+            emptyList()
+        }
+    }
+
+    /**
+     * Generates postprocessor args for hardware-accelerated H.264 encoding.
+     * Returns null if no hardware encoder is available.
+     *
+     * @param ffmpegPath Path to the FFmpeg executable
+     * @return The postprocessor args string or null if no HW encoder available
+     */
+    fun getHwPostprocessorArgs(ffmpegPath: String): String? {
+        val encoder = getBestH264Encoder(ffmpegPath) ?: return null
+
+        return when (encoder) {
+            "h264_nvenc" -> "ffmpeg:-c:v h264_nvenc -preset p4 -cq 23"
+            "h264_qsv" -> "ffmpeg:-c:v h264_qsv -preset medium -global_quality 23"
+            "h264_amf" -> "ffmpeg:-c:v h264_amf -quality balanced -qp_i 23 -qp_p 23"
+            "h264_videotoolbox" -> "ffmpeg:-c:v h264_videotoolbox -q:v 65"
+            "h264_vaapi" -> "ffmpeg:-c:v h264_vaapi -qp 23"
+            else -> null
+        }
+    }
+
+    /**
+     * Clears the cached encoder detection result.
+     * Call this if the FFmpeg installation changes.
+     */
+    fun clearCache() {
+        synchronized(this) {
+            cachedH264Encoder = null
+            detectionAttempted = false
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add trim/cut feature to SingleDownloadScreen using yt-dlp's `--download-sections` argument
- Add automatic hardware acceleration detection for re-encoding (NVENC, QSV, AMF, VideoToolbox, VAAPI)
- Create shared `TrimSlider` component to avoid code duplication with converter screen
- Refactor ConverterOptionsScreen to use the shared component
- Rename string key `download` to `tasks` for consistency

## Test plan
- [ ] Open a video in the download screen and verify the trim slider appears
- [ ] Adjust trim range and verify duration display updates correctly
- [ ] Download a trimmed video and verify the output has the correct duration
- [ ] Verify hardware acceleration is detected in logs when re-encoding