### PR TITLE
fix(ytdlp): pass --js-runtimes to metadata extraction

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,7 @@ cardiologist = "0.8.0"
 # UI Libraries
 fluent = "v0.1.0"
 composemediaplayer = "0.8.7"
-composenativetray = "1.0.7"
+composenativetray = "1.0.9"
 composewebview = "1.0.0-alpha-10"
 
 # Network & Tools

--- a/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/YtDlpWrapper.kt
+++ b/ytdlp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlp/YtDlpWrapper.kt
@@ -878,6 +878,7 @@ class YtDlpWrapper {
             // Aggressively cap network timeouts for faster failures (does not affect cache semantics)
             addAll(listOf("--socket-timeout", "5"))
             if (useNoCheckCert) add("--no-check-certificate")
+            denoPath?.takeIf { it.isNotBlank() }?.let { addAll(listOf("--js-runtimes", "deno:$it")) }
             cookiesFromBrowser?.takeIf { it.isNotBlank() }?.let { addAll(listOf("--cookies-from-browser", it)) }
             proxy?.takeIf { it.isNotBlank() }?.let { addAll(listOf("--proxy", it)) }
             addAll(extraArgs); add(url)


### PR DESCRIPTION
## Summary
- **Fix**: `extractMetadata()` was missing the `--js-runtimes deno:$path` flag that `buildCommand()` already passes for downloads. When `--cookies-from-browser` is active, YouTube requires solving a JS n-parameter challenge — without deno, yt-dlp only retrieves storyboard images, causing "Requested format is not available" errors.
- **Deps**: bump composenativetray 1.0.7 → 1.0.9

## Test plan
- [ ] Launch the app with `cookiesFromBrowser` set to a browser (e.g. firefox)
- [ ] Paste a YouTube URL and verify video info loads without "Requested format is not available" error
- [ ] Verify downloads still work as before