### PR TITLE
fix: show app name in Windows Task Manager

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -168,7 +168,7 @@ compose.desktop {
             targetFormats(TargetFormat.Pkg, TargetFormat.Msi, TargetFormat.Deb, TargetFormat.Rpm, TargetFormat.Dmg)
             packageName = "AeroDl"
             packageVersion = version
-            description = "An awesome GUI for yt-dlp!"
+            description = "AeroDl"
 
             // JVM args for performance optimization
             jvmArgs += listOf(


### PR DESCRIPTION
## Summary
- Changed `nativeDistributions.description` from `"An awesome GUI for yt-dlp!"` to `"AeroDl"` so that Windows Task Manager and file properties display the correct application name instead of a generic description.

Closes #73

## Test plan
- [ ] Build and package for Windows (`packageMsi` or `createDistributable`)
- [ ] Verify the `.exe` file properties show "AeroDl" as the description
- [ ] Verify Windows Task Manager displays "AeroDl"