### PR TITLE
feat(build): add Project Leyden AOT cache for faster startup

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -119,29 +119,33 @@ jobs:
           echo "$JAVA_HOME/bin" >> "$GITHUB_PATH"
           echo "Detected JBR at: $JAVA_HOME"
 
+      # Headless display for AOT training (Linux needs Xvfb)
+      - name: Setup headless display
+        uses: pyvista/setup-headless-display-action@v3
+
       # Gradle Setup
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v3
         with:
           gradle-version: '8.14'
 
-      # Builds
+      # Builds (AOT cache is automatically generated via task dependencies)
       - name: Build Linux .deb
         if: startsWith(matrix.os, 'ubuntu') && matrix.pkg == 'deb'
         run: |
           chmod +x ./gradlew
-          ./gradlew :composeApp:createReleaseDistributable :composeApp:packageReleaseDeb
+          ./gradlew :composeApp:packageReleaseDeb
 
       - name: Build Linux .rpm
         if: startsWith(matrix.os, 'ubuntu') && matrix.pkg == 'rpm'
         run: |
           chmod +x ./gradlew
-          ./gradlew :composeApp:createReleaseDistributable :composeApp:packageReleaseRpm
+          ./gradlew :composeApp:packageReleaseRpm
 
       - name: Build Windows .msi
         if: startsWith(matrix.os, 'windows')
         shell: pwsh
-        run: .\gradlew.bat :composeApp:createReleaseDistributable :composeApp:packageReleaseMsi
+        run: .\gradlew.bat :composeApp:packageReleaseMsi
 
       - name: Build macOS .pkg + .dmg + .zip
         if: startsWith(matrix.os, 'macos')
@@ -149,7 +153,7 @@ jobs:
         run: |
           set -euo pipefail
           chmod +x ./gradlew
-          ./gradlew :composeApp:createReleaseDistributable :composeApp:packageReleasePkg :composeApp:packageReleaseDmg
+          ./gradlew :composeApp:packageReleasePkg :composeApp:packageReleaseDmg
           APP_DIR="composeApp/build/compose/binaries/main-release/app"
           APP_BUNDLE=$(find "$APP_DIR" -mindepth 1 -maxdepth 1 -type d -name '*.app' | head -n 1 || true)
           if [ -z "$APP_BUNDLE" ]; then
@@ -162,6 +166,34 @@ jobs:
           ZIP_NAME="${BASENAME}-mac-${ARCH}.zip"
           echo "Creating ZIP $ZIP_NAME from $(basename "$APP_BUNDLE") in $(dirname "$APP_BUNDLE")"
           (cd "$(dirname "$APP_BUNDLE")" && zip -r "$ZIP_NAME" "$(basename "$APP_BUNDLE")")
+
+      # Verify AOT cache was generated
+      - name: Verify AOT cache exists
+        shell: bash
+        run: |
+          AOT_FILE=$(find composeApp/build/compose/binaries -name "aerodl.aot" -type f 2>/dev/null | head -1)
+          if [ -z "$AOT_FILE" ]; then
+            echo "ERROR: aerodl.aot not found!"
+            exit 1
+          fi
+          SIZE=$(stat -f%z "$AOT_FILE" 2>/dev/null || stat -c%s "$AOT_FILE" 2>/dev/null)
+          echo "AOT cache found: $AOT_FILE ($((SIZE / 1024 / 1024)) MB)"
+
+      - name: Verify AOTCache injected in .cfg
+        shell: bash
+        run: |
+          CFG_FILE=$(find composeApp/build/compose/binaries -name "*.cfg" -type f 2>/dev/null | head -1)
+          if [ -z "$CFG_FILE" ]; then
+            echo "ERROR: No .cfg file found!"
+            exit 1
+          fi
+          if grep -q "AOTCache" "$CFG_FILE"; then
+            echo "OK: AOTCache directive found in $CFG_FILE"
+            grep "AOTCache" "$CFG_FILE"
+          else
+            echo "ERROR: AOTCache not found in $CFG_FILE"
+            exit 1
+          fi
 
       # Upload Artifacts
       - name: Upload Linux .deb (amd64/arm64)

--- a/.github/workflows/test-aot.yaml
+++ b/.github/workflows/test-aot.yaml
@@ -1,0 +1,144 @@
+name: Test AOT Cache
+
+on:
+  pull_request:
+    paths:
+      - 'composeApp/build.gradle.kts'
+      - '.github/workflows/test-aot.yaml'
+
+jobs:
+  test-aot:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            jdk_url: "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-linux-x64-b176.4.tar.gz"
+            name: Linux x64
+            package_task: packageReleaseDeb
+            artifact_name: linux-deb-x64
+            artifact_path: composeApp/build/compose/binaries/main-release/deb/*.deb
+          - os: ubuntu-24.04-arm
+            jdk_url: "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-linux-aarch64-b176.4.tar.gz"
+            name: Linux ARM64
+            package_task: packageReleaseDeb
+            artifact_name: linux-deb-arm64
+            artifact_path: composeApp/build/compose/binaries/main-release/deb/*.deb
+          - os: macos-latest
+            jdk_url: "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-osx-aarch64-b176.4.tar.gz"
+            name: macOS ARM64
+            package_task: packageReleaseDmg
+            artifact_name: macos-dmg-arm64
+            artifact_path: composeApp/build/compose/binaries/main-release/dmg/*.dmg
+          - os: macos-15-intel
+            jdk_url: "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-osx-x64-b176.4.tar.gz"
+            name: macOS Intel
+            package_task: packageReleaseDmg
+            artifact_name: macos-dmg-x64
+            artifact_path: composeApp/build/compose/binaries/main-release/dmg/*.dmg
+          - os: windows-latest
+            jdk_url: "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-windows-x64-b176.4.zip"
+            name: Windows x64
+            package_task: packageReleaseMsi
+            artifact_name: windows-msi-x64
+            artifact_path: composeApp/build/compose/binaries/main-release/msi/*.msi
+          - os: windows-11-arm
+            jdk_url: "https://cache-redirector.jetbrains.com/intellij-jbr/jbrsdk-25-windows-aarch64-b176.4.zip"
+            name: Windows ARM64
+            package_task: packageReleaseMsi
+            artifact_name: windows-msi-arm64
+            artifact_path: composeApp/build/compose/binaries/main-release/msi/*.msi
+
+    name: AOT - ${{ matrix.name }}
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup headless display
+        uses: pyvista/setup-headless-display-action@v3
+
+      - name: Install JBR (Linux)
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -L -o jbr.tar.gz "${{ matrix.jdk_url }}"
+          mkdir -p "$RUNNER_TEMP/jbr"
+          tar -xzf jbr.tar.gz -C "$RUNNER_TEMP/jbr"
+          JBR_DIR=$(find "$RUNNER_TEMP/jbr" -mindepth 1 -maxdepth 1 -type d | head -n 1)
+          echo "JAVA_HOME=$JBR_DIR" >> "$GITHUB_ENV"
+          echo "$JBR_DIR/bin" >> "$GITHUB_PATH"
+
+      - name: Install JBR (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -L -o jbr.tar.gz "${{ matrix.jdk_url }}"
+          mkdir -p "$RUNNER_TEMP/jbr"
+          tar -xzf jbr.tar.gz -C "$RUNNER_TEMP/jbr"
+          ROOT_DIR=$(find "$RUNNER_TEMP/jbr" -mindepth 1 -maxdepth 1 -type d | head -n 1)
+          JAVA_HOME="$ROOT_DIR/Contents/Home"
+          echo "JAVA_HOME=$JAVA_HOME" >> "$GITHUB_ENV"
+          echo "$JAVA_HOME/bin" >> "$GITHUB_PATH"
+
+      - name: Install JBR (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest -Uri "${{ matrix.jdk_url }}" -OutFile "$env:RUNNER_TEMP\jbr.zip"
+          Expand-Archive -Path "$env:RUNNER_TEMP\jbr.zip" -DestinationPath "$env:RUNNER_TEMP\jbr" -Force
+          $jbrDir = Get-ChildItem "$env:RUNNER_TEMP\jbr" | Where-Object { $_.PSIsContainer } | Select-Object -First 1
+          "$([string]::Format('JAVA_HOME={0}', $jbrDir.FullName))" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          "$($jbrDir.FullName)\bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+
+      - name: Set up Gradle
+        uses: gradle/gradle-build-action@v3
+
+      - name: Verify JDK
+        shell: bash
+        run: java -version
+
+      - name: Build installer with AOT cache
+        shell: bash
+        run: |
+          chmod +x ./gradlew
+          ./gradlew :composeApp:${{ matrix.package_task }}
+
+      - name: Verify AOT cache exists
+        shell: bash
+        run: |
+          AOT_FILE=$(find composeApp/build/compose/binaries -name "aerodl.aot" -type f 2>/dev/null | head -1)
+          if [ -z "$AOT_FILE" ]; then
+            echo "ERROR: aerodl.aot not found!"
+            exit 1
+          fi
+          SIZE=$(stat -f%z "$AOT_FILE" 2>/dev/null || stat -c%s "$AOT_FILE" 2>/dev/null)
+          echo "AOT cache found: $AOT_FILE ($((SIZE / 1024 / 1024)) MB)"
+
+      - name: Verify AOTCache injected in .cfg
+        shell: bash
+        run: |
+          CFG_FILE=$(find composeApp/build/compose/binaries -name "*.cfg" -type f 2>/dev/null | head -1)
+          if [ -z "$CFG_FILE" ]; then
+            echo "ERROR: No .cfg file found!"
+            exit 1
+          fi
+          if grep -q "AOTCache" "$CFG_FILE"; then
+            echo "OK: AOTCache directive found in $CFG_FILE"
+            grep "AOTCache" "$CFG_FILE"
+          else
+            echo "ERROR: AOTCache not found in $CFG_FILE"
+            exit 1
+          fi
+
+      - name: Upload installer
+        uses: actions/upload-artifact@v5
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_path }}
+          if-no-files-found: error

--- a/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/AotCacheHelper.kt
+++ b/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/AotCacheHelper.kt
@@ -1,0 +1,52 @@
+package io.github.kdroidfilter.buildsrc
+
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPluginExtension
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.jvm.toolchain.JavaToolchainService
+
+/**
+ * Configuration for AOT cache generation.
+ */
+data class AotCacheConfig(
+    val aotCacheFileName: String = "aerodl.aot",
+    val trainDurationSeconds: Long = 20L
+)
+
+/**
+ * Helper to register AOT cache generation tasks.
+ */
+object AotCacheHelper {
+
+    /**
+     * Registers a task to generate an AOT cache for a distributable.
+     *
+     * @param project The Gradle project
+     * @param taskName Name for the registered task
+     * @param dependsOnTask Task that creates the distributable
+     * @param binariesSubdir Subdirectory under compose/binaries (e.g., "main" or "main-release")
+     * @param config Configuration for AOT generation
+     * @return The registered task provider
+     */
+    fun registerTask(
+        project: Project,
+        taskName: String,
+        dependsOnTask: String,
+        binariesSubdir: String,
+        config: AotCacheConfig = AotCacheConfig()
+    ): TaskProvider<AotCacheTask> {
+        // Resolve toolchain java path at configuration time (configuration cache compatible)
+        val javaToolchain = project.extensions.getByType(JavaPluginExtension::class.java).toolchain
+        val javaToolchainService = project.extensions.getByType(JavaToolchainService::class.java)
+        val javaLauncher = javaToolchainService.launcherFor(javaToolchain)
+
+        return project.tasks.register(taskName, AotCacheTask::class.java) {
+            description = "Generate an AOT cache for the $binariesSubdir distributable"
+            dependsOn(project.tasks.named(dependsOnTask))
+            distributableDir.set(project.layout.buildDirectory.dir("compose/binaries/$binariesSubdir/app"))
+            aotCacheFileName.set(config.aotCacheFileName)
+            trainDurationSeconds.set(config.trainDurationSeconds)
+            toolchainJavaExe.set(javaLauncher.map { it.executablePath.asFile.absolutePath })
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/AotCacheTask.kt
+++ b/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/AotCacheTask.kt
@@ -1,0 +1,321 @@
+package io.github.kdroidfilter.buildsrc
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+
+/**
+ * Generates an AOT (Ahead-of-Time) cache for a Compose Desktop distributable.
+ *
+ * This task:
+ * 1. Locates the distributable app directory
+ * 2. Provisions a java launcher in the bundled runtime (if needed)
+ * 3. Records class loading by running the app for a training period
+ * 4. Creates an AOT cache from the recorded profile
+ * 5. Injects the AOT cache path into the app's .cfg file
+ */
+@DisableCachingByDefault(because = "AOT cache generation depends on runtime behavior")
+abstract class AotCacheTask : DefaultTask() {
+
+    @get:InputDirectory
+    abstract val distributableDir: DirectoryProperty
+
+    @get:Input
+    abstract val aotCacheFileName: Property<String>
+
+    @get:Input
+    abstract val trainDurationSeconds: Property<Long>
+
+    @get:Input
+    abstract val toolchainJavaExe: Property<String>
+
+    init {
+        group = "compose desktop"
+        aotCacheFileName.convention("aerodl.aot")
+        trainDurationSeconds.convention(20L)
+    }
+
+    @TaskAction
+    fun execute() {
+        val baseDir = distributableDir.get().asFile
+        val appDir = baseDir.listFiles()?.firstOrNull { it.isDirectory }
+            ?: throw GradleException("Distributable app directory not found under $baseDir")
+
+        logger.lifecycle("[aotCache] Processing ${appDir.name}")
+
+        // Find app JAR directory (platform-specific)
+        val appJarDir = findAppJarDir(appDir)
+
+        // Provision java launcher in bundled runtime
+        val (javaExe, cleanUpJava) = provisionJavaLauncher(appDir)
+
+        try {
+            // Parse .cfg file
+            val cfgFile = appJarDir.listFiles()?.firstOrNull { it.extension == "cfg" }
+                ?: throw GradleException("No .cfg file found in $appJarDir")
+            val (classpath, javaOptions, mainClass) = parseCfgFile(cfgFile, appJarDir)
+
+            // Generate AOT cache
+            val aotCacheFile = File(appJarDir, aotCacheFileName.get())
+            generateAotCache(javaExe, appDir, appJarDir, classpath, javaOptions, mainClass, aotCacheFile)
+
+            // Inject AOT cache into .cfg
+            injectAotCacheIntoCfg(cfgFile, aotCacheFileName.get())
+
+            logger.lifecycle("[aotCache] Complete: ${aotCacheFile.absolutePath} (${aotCacheFile.length() / 1024}KB)")
+        } finally {
+            if (cleanUpJava) {
+                logger.lifecycle("[aotCache] Keeping provisioned java launcher for --app-image packaging")
+            }
+        }
+    }
+
+    private fun findAppJarDir(appDir: File): File {
+        return listOf(
+            File(appDir, "Contents/app"),  // macOS
+            File(appDir, "app"),           // Windows
+            File(appDir, "lib/app")        // Linux
+        ).firstOrNull { it.exists() }
+            ?: throw GradleException("app/ subdirectory not found in $appDir")
+    }
+
+    private fun provisionJavaLauncher(appDir: File): Pair<String, Boolean> {
+        val javaExePath = toolchainJavaExe.get()
+
+        val runtimeHome = listOf(
+            File(appDir, "Contents/runtime/Contents/Home"), // macOS
+            File(appDir, "runtime"),                        // Windows
+            File(appDir, "lib/runtime")                     // Linux
+        ).firstOrNull { it.exists() }
+
+        if (runtimeHome == null) {
+            logger.warn("[aotCache] Bundled runtime not found, using toolchain java")
+            return javaExePath to false
+        }
+
+        val runtimeBinDir = File(runtimeHome, "bin")
+        val isWindows = System.getProperty("os.name").lowercase().contains("windows")
+        val exeName = if (isWindows) "java.exe" else "java"
+        val provisionedJava = File(runtimeBinDir, exeName)
+
+        // Check if launcher already exists
+        if (provisionedJava.exists()) {
+            return provisionedJava.absolutePath to false
+        }
+
+        // Provision java launcher
+        runtimeBinDir.mkdirs()
+        File(javaExePath).copyTo(provisionedJava, overwrite = true)
+        provisionedJava.setExecutable(true)
+
+        // Copy essential DLLs on Windows
+        if (isWindows) {
+            copyWindowsDlls(File(javaExePath).parentFile, runtimeBinDir)
+        }
+
+        logger.lifecycle("[aotCache] Provisioned java launcher at ${provisionedJava.absolutePath}")
+        return provisionedJava.absolutePath to true
+    }
+
+    private fun copyWindowsDlls(toolchainBinDir: File, runtimeBinDir: File) {
+        val essentialDlls = setOf(
+            "jli.dll", "vcruntime140.dll", "msvcp140.dll", "ucrtbase.dll"
+        )
+        toolchainBinDir.listFiles()
+            ?.filter { it.extension.lowercase() == "dll" && it.name.lowercase() in essentialDlls }
+            ?.forEach { dll ->
+                val target = File(runtimeBinDir, dll.name)
+                if (!target.exists()) {
+                    dll.copyTo(target, overwrite = false)
+                }
+            }
+    }
+
+    private data class CfgParseResult(
+        val classpath: String,
+        val javaOptions: List<String>,
+        val mainClass: String
+    )
+
+    private fun parseCfgFile(cfgFile: File, appJarDir: File): CfgParseResult {
+        val cpEntries = mutableListOf<String>()
+        val javaOptions = mutableListOf<String>()
+        var mainClass = ""
+        var inClasspath = false
+        var inJavaOptions = false
+
+        for (line in cfgFile.readLines()) {
+            val trimmed = line.trim()
+            when {
+                trimmed == "[JavaOptions]" -> { inJavaOptions = true; inClasspath = false }
+                trimmed == "[ClassPath]" -> { inClasspath = true; inJavaOptions = false }
+                trimmed == "[Application]" || trimmed == "[ArgOptions]" -> { inClasspath = false; inJavaOptions = false }
+                trimmed.startsWith("app.mainclass=") -> mainClass = trimmed.substringAfter("app.mainclass=").trim()
+                trimmed.startsWith("app.classpath=") -> cpEntries += trimmed.substringAfter("app.classpath=").trim()
+                trimmed.startsWith("[") -> { inClasspath = false; inJavaOptions = false }
+                inClasspath && trimmed.isNotEmpty() -> cpEntries += trimmed
+                inJavaOptions && trimmed.isNotEmpty() -> {
+                    val opt = if (trimmed.startsWith("java-options=")) trimmed.substringAfter("java-options=") else trimmed
+                    if (!opt.contains("AOTCache")) {
+                        javaOptions += opt.replace("\$APPDIR", appJarDir.absolutePath)
+                    }
+                }
+            }
+        }
+
+        val classpath = cpEntries.joinToString(File.pathSeparator) { entry ->
+            File(entry.replace("\$APPDIR", appJarDir.absolutePath)).absolutePath
+        }
+
+        return CfgParseResult(classpath, javaOptions, mainClass)
+    }
+
+    private fun generateAotCache(
+        javaExe: String,
+        appDir: File,
+        appJarDir: File,
+        classpath: String,
+        javaOptions: List<String>,
+        mainClass: String,
+        aotCacheFile: File
+    ) {
+        val trainDuration = trainDurationSeconds.get()
+        val aotConfigFile = File.createTempFile("aerodl-aot-", ".aotconf")
+
+        val options = javaOptions.toMutableList()
+        options += "-Daot.training.autoExit=$trainDuration"
+
+        // Step 1: Record
+        logger.lifecycle("[aotCache] Recording class loading profile (~${trainDuration}s)...")
+        recordAotProfile(javaExe, appDir, classpath, options, mainClass, aotConfigFile, trainDuration)
+
+        if (!aotConfigFile.exists() || aotConfigFile.length() == 0L) {
+            throw GradleException("AOT configuration file was not created")
+        }
+        logger.lifecycle("[aotCache] Recorded ${aotConfigFile.length() / 1024}KB of profile data")
+
+        // Step 2: Create cache
+        logger.lifecycle("[aotCache] Creating cache...")
+        createAotCache(javaExe, appDir, classpath, options, mainClass, aotConfigFile, aotCacheFile)
+
+        aotConfigFile.delete()
+
+        if (!aotCacheFile.exists()) {
+            throw GradleException("AOT cache file was not created")
+        }
+    }
+
+    private fun recordAotProfile(
+        javaExe: String,
+        appDir: File,
+        classpath: String,
+        javaOptions: List<String>,
+        mainClass: String,
+        aotConfigFile: File,
+        trainDuration: Long
+    ) {
+        val args = mutableListOf(javaExe)
+        args += listOf("-XX:AOTMode=record", "-XX:AOTConfiguration=${aotConfigFile.absolutePath}", "-cp", classpath)
+        args += javaOptions
+        args += mainClass
+
+        val logFile = File.createTempFile("aerodl-aot-record-", ".log")
+        val processBuilder = ProcessBuilder(args)
+            .directory(appDir)
+            .redirectErrorStream(true)
+            .redirectOutput(logFile)
+
+        // Handle headless Linux with Xvfb
+        val os = System.getProperty("os.name").lowercase()
+        val isLinux = os.contains("linux")
+        val needsXvfb = isLinux && System.getenv("DISPLAY").isNullOrEmpty()
+
+        var xvfbProcess: Process? = null
+        if (needsXvfb) {
+            val display = ":99"
+            xvfbProcess = ProcessBuilder("Xvfb", display, "-screen", "0", "1280x1024x24")
+                .redirectErrorStream(true)
+                .start()
+            Thread.sleep(1000)
+            processBuilder.environment()["DISPLAY"] = display
+            logger.lifecycle("[aotCache] Started Xvfb on $display")
+        }
+
+        val process = processBuilder.start()
+
+        // Wait for app to self-terminate
+        val deadline = System.currentTimeMillis() + (trainDuration + 30) * 1000
+        while (process.isAlive && System.currentTimeMillis() < deadline) {
+            Thread.sleep(500)
+        }
+        if (process.isAlive) {
+            logger.warn("[aotCache] App did not self-terminate, forcing kill")
+            process.destroyForcibly()
+        }
+
+        val exitCode = process.waitFor()
+        xvfbProcess?.destroyForcibly()
+
+        // Log output for debugging
+        val output = logFile.readText().takeLast(3000)
+        if (output.isNotBlank()) {
+            logger.lifecycle("[aotCache] Record output (exit $exitCode):\n$output")
+        }
+        logFile.delete()
+
+        // Check for JVM crash dumps
+        appDir.listFiles()?.filter { it.name.startsWith("hs_err_pid") }?.forEach { hsErr ->
+            logger.lifecycle("[aotCache] JVM crash dump: ${hsErr.name}")
+            logger.lifecycle(hsErr.readText().take(2000))
+            hsErr.delete()
+        }
+    }
+
+    private fun createAotCache(
+        javaExe: String,
+        appDir: File,
+        classpath: String,
+        javaOptions: List<String>,
+        mainClass: String,
+        aotConfigFile: File,
+        aotCacheFile: File
+    ) {
+        val args = mutableListOf(javaExe)
+        args += listOf(
+            "-XX:AOTMode=create",
+            "-XX:AOTConfiguration=${aotConfigFile.absolutePath}",
+            "-XX:AOTCache=${aotCacheFile.absolutePath}",
+            "-cp", classpath
+        )
+        args += javaOptions
+        args += mainClass
+
+        val process = ProcessBuilder(args)
+            .directory(appDir)
+            .inheritIO()
+            .start()
+
+        val exitCode = process.waitFor()
+        if (exitCode != 0) {
+            throw GradleException("AOT cache creation failed with exit code $exitCode")
+        }
+    }
+
+    private fun injectAotCacheIntoCfg(cfgFile: File, aotCacheFileName: String) {
+        val content = cfgFile.readText()
+        if (!content.contains("AOTCache")) {
+            val updatedContent = content.replace(
+                "[JavaOptions]",
+                "[JavaOptions]\njava-options=-XX:AOTCache=\$APPDIR/$aotCacheFileName"
+            )
+            cfgFile.writeText(updatedContent)
+            logger.lifecycle("[aotCache] Injected AOTCache into ${cfgFile.name}")
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/DebPostProcessHelper.kt
+++ b/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/DebPostProcessHelper.kt
@@ -1,0 +1,50 @@
+package io.github.kdroidfilter.buildsrc
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * Configuration for .deb post-processing.
+ */
+data class DebPostProcessConfig(
+    val packageName: String = "aerodl",
+    val appName: String = "AeroDl",
+    val execPath: String = "/opt/aerodl/bin/AeroDl",
+    val iconPath: String = "/opt/aerodl/lib/AeroDl.png",
+    val startupWMClass: String? = null,
+    val categories: String = "AudioVideo;Audio;Video;Network;",
+    val enableT64AlternativeDeps: Boolean = true
+)
+
+/**
+ * Helper to register .deb post-processing tasks.
+ */
+object DebPostProcessHelper {
+
+    /**
+     * Registers a task to post-process a .deb file.
+     *
+     * @param project The Gradle project
+     * @param taskName Name for the registered task
+     * @param buildType Build type path (e.g., "main-release" or "main")
+     * @param config Configuration for the post-processing
+     * @return The registered task provider
+     */
+    fun registerTask(
+        project: Project,
+        taskName: String,
+        buildType: String,
+        config: DebPostProcessConfig = DebPostProcessConfig()
+    ): TaskProvider<DebPostProcessTask> {
+        return project.tasks.register(taskName, DebPostProcessTask::class.java) {
+            debDirectory.set(project.layout.buildDirectory.dir("compose/binaries/$buildType/deb"))
+            packageName.set(config.packageName)
+            appName.set(config.appName)
+            execPath.set(config.execPath)
+            iconPath.set(config.iconPath)
+            config.startupWMClass?.let { startupWMClass.set(it) }
+            categories.set(config.categories)
+            enableT64AlternativeDeps.set(config.enableT64AlternativeDeps)
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/DebPostProcessTask.kt
+++ b/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/DebPostProcessTask.kt
@@ -1,0 +1,220 @@
+package io.github.kdroidfilter.buildsrc
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+
+/**
+ * Post-processes a .deb package to:
+ * - Inject a .desktop file (required when using jpackage --app-image mode)
+ * - Fix t64 dependencies for Ubuntu 24.04 compatibility
+ */
+@DisableCachingByDefault(because = "Modifies .deb in place")
+abstract class DebPostProcessTask : DefaultTask() {
+
+    @get:InputDirectory
+    abstract val debDirectory: DirectoryProperty
+
+    @get:Input
+    abstract val packageName: Property<String>
+
+    @get:Input
+    abstract val appName: Property<String>
+
+    @get:Input
+    abstract val execPath: Property<String>
+
+    @get:Input
+    abstract val iconPath: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val startupWMClass: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val categories: Property<String>
+
+    @get:Input
+    abstract val enableT64AlternativeDeps: Property<Boolean>
+
+    init {
+        group = "distribution"
+        description = "Post-process .deb: inject .desktop file and fix dependencies"
+
+        // Set defaults
+        categories.convention("AudioVideo;Audio;Video;Network;")
+        enableT64AlternativeDeps.convention(true)
+    }
+
+    @TaskAction
+    fun execute() {
+        if (!System.getProperty("os.name").lowercase().contains("linux")) {
+            logger.lifecycle("[debPostProcess] Skipped (non-Linux OS)")
+            return
+        }
+
+        val debDir = debDirectory.get().asFile
+        val debFile = debDir.listFiles()?.firstOrNull { it.extension == "deb" }
+        if (debFile == null) {
+            logger.warn("[debPostProcess] No .deb file found in ${debDir.absolutePath}")
+            return
+        }
+
+        logger.lifecycle("[debPostProcess] Processing ${debFile.name}")
+
+        val workDir = File(debFile.parentFile, "deb-work")
+        try {
+            processDebFile(debFile, workDir)
+        } finally {
+            workDir.deleteRecursively()
+        }
+    }
+
+    private fun processDebFile(debFile: File, workDir: File) {
+        val extractDir = File(workDir, "extract")
+        val dataDir = File(workDir, "data")
+        val controlDir = File(workDir, "control")
+
+        // Clean and create work directories
+        workDir.deleteRecursively()
+        listOf(extractDir, dataDir, controlDir).forEach { it.mkdirs() }
+
+        // Extract .deb archive
+        exec("ar", "x", debFile.absolutePath, workDir = extractDir)
+
+        // Find data.tar.*
+        val dataTar = extractDir.listFiles()?.firstOrNull { it.name.startsWith("data.tar") }
+            ?: error("data.tar.* not found in .deb")
+
+        // Extract data.tar
+        extractTar(dataTar, dataDir)
+
+        // Create .desktop file
+        createDesktopFile(dataDir)
+
+        // Recompress data.tar
+        val newDataTar = File(extractDir, dataTar.name)
+        dataTar.delete()
+        compressTar(newDataTar, dataDir)
+
+        // Process control.tar if t64 deps enabled
+        val controlTar = extractDir.listFiles()?.firstOrNull { it.name.startsWith("control.tar") }
+        if (controlTar != null && enableT64AlternativeDeps.get()) {
+            extractTar(controlTar, controlDir)
+            fixT64Dependencies(controlDir)
+            val newControlTar = File(extractDir, controlTar.name)
+            controlTar.delete()
+            compressTar(newControlTar, controlDir)
+        }
+
+        // Rebuild .deb
+        rebuildDeb(debFile, extractDir)
+
+        logger.lifecycle("[debPostProcess] Successfully processed ${debFile.name}")
+    }
+
+    private fun createDesktopFile(dataDir: File) {
+        val appsDir = File(dataDir, "usr/share/applications")
+        appsDir.mkdirs()
+
+        val desktopFileName = "${packageName.get()}-${appName.get()}.desktop"
+        val desktopFile = File(appsDir, desktopFileName)
+
+        val content = buildString {
+            appendLine("[Desktop Entry]")
+            appendLine("Name=${appName.get()}")
+            appendLine("Comment=${appName.get()}")
+            appendLine("Exec=${execPath.get()} %U")
+            appendLine("Icon=${iconPath.get()}")
+            appendLine("Terminal=false")
+            appendLine("Type=Application")
+            appendLine("Categories=${categories.get()}")
+            if (startupWMClass.isPresent) {
+                appendLine("StartupWMClass=${startupWMClass.get()}")
+            }
+        }
+
+        desktopFile.writeText(content)
+        logger.lifecycle("[debPostProcess] Created ${desktopFile.name}")
+    }
+
+    private fun fixT64Dependencies(controlDir: File) {
+        val controlFile = File(controlDir, "control")
+        if (!controlFile.exists()) return
+
+        var content = controlFile.readText()
+        val t64Mappings = mapOf(
+            "libc6" to "libc6 | libc6t64",
+            "libgtk-3-0" to "libgtk-3-0 | libgtk-3-0t64",
+            "libglib2.0-0" to "libglib2.0-0 | libglib2.0-0t64",
+            "libx11-6" to "libx11-6 | libx11-6t64"
+        )
+
+        var modified = false
+        for ((old, new) in t64Mappings) {
+            if (content.contains(old) && !content.contains("$old |") && !content.contains("| ${old}t64")) {
+                content = content.replace(Regex("\\b${Regex.escape(old)}\\b(?!t64)"), new)
+                modified = true
+            }
+        }
+
+        if (modified) {
+            controlFile.writeText(content)
+            logger.lifecycle("[debPostProcess] Updated control file with t64 alternatives")
+        }
+    }
+
+    private fun extractTar(tarFile: File, destDir: File) {
+        val args = when {
+            tarFile.name.endsWith(".zst") -> listOf("tar", "--zstd", "-xf", tarFile.absolutePath, "-C", destDir.absolutePath)
+            tarFile.name.endsWith(".xz") -> listOf("tar", "-xJf", tarFile.absolutePath, "-C", destDir.absolutePath)
+            tarFile.name.endsWith(".gz") -> listOf("tar", "-xzf", tarFile.absolutePath, "-C", destDir.absolutePath)
+            else -> listOf("tar", "-xf", tarFile.absolutePath, "-C", destDir.absolutePath)
+        }
+        exec(*args.toTypedArray())
+    }
+
+    private fun compressTar(tarFile: File, sourceDir: File) {
+        val cmd = when {
+            tarFile.name.endsWith(".zst") -> "tar -cf - -C ${sourceDir.absolutePath} . | zstd -19 -o ${tarFile.absolutePath}"
+            tarFile.name.endsWith(".xz") -> "tar -cJf ${tarFile.absolutePath} -C ${sourceDir.absolutePath} ."
+            tarFile.name.endsWith(".gz") -> "tar -czf ${tarFile.absolutePath} -C ${sourceDir.absolutePath} ."
+            else -> "tar -cf ${tarFile.absolutePath} -C ${sourceDir.absolutePath} ."
+        }
+        exec("sh", "-c", cmd)
+    }
+
+    private fun rebuildDeb(debFile: File, extractDir: File) {
+        val debianBinary = File(extractDir, "debian-binary")
+        val controlTar = extractDir.listFiles()?.firstOrNull { it.name.startsWith("control.tar") }
+        val dataTar = extractDir.listFiles()?.firstOrNull { it.name.startsWith("data.tar") }
+
+        if (debianBinary.exists() && controlTar != null && dataTar != null) {
+            debFile.delete()
+            exec("ar", "rcs", debFile.absolutePath,
+                debianBinary.absolutePath, controlTar.absolutePath, dataTar.absolutePath)
+        } else {
+            error("Missing components to rebuild .deb")
+        }
+    }
+
+    private fun exec(vararg args: String, workDir: File? = null) {
+        val process = ProcessBuilder(*args)
+            .apply { workDir?.let { directory(it) } }
+            .redirectErrorStream(true)
+            .start()
+
+        val exitCode = process.waitFor()
+        if (exitCode != 0) {
+            val output = process.inputStream.bufferedReader().readText()
+            error("Command failed with exit code $exitCode: ${args.joinToString(" ")}\n$output")
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/RpmPostProcessHelper.kt
+++ b/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/RpmPostProcessHelper.kt
@@ -1,0 +1,48 @@
+package io.github.kdroidfilter.buildsrc
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.TaskProvider
+
+/**
+ * Configuration for .rpm post-processing.
+ */
+data class RpmPostProcessConfig(
+    val packageName: String = "aerodl",
+    val appName: String = "AeroDl",
+    val execPath: String = "/opt/aerodl/bin/AeroDl",
+    val iconPath: String = "/opt/aerodl/lib/AeroDl.png",
+    val startupWMClass: String? = null,
+    val categories: String = "AudioVideo;Audio;Video;Network;"
+)
+
+/**
+ * Helper to register .rpm post-processing tasks.
+ */
+object RpmPostProcessHelper {
+
+    /**
+     * Registers a task to post-process a .rpm file.
+     *
+     * @param project The Gradle project
+     * @param taskName Name for the registered task
+     * @param buildType Build type path (e.g., "main-release" or "main")
+     * @param config Configuration for the post-processing
+     * @return The registered task provider
+     */
+    fun registerTask(
+        project: Project,
+        taskName: String,
+        buildType: String,
+        config: RpmPostProcessConfig = RpmPostProcessConfig()
+    ): TaskProvider<RpmPostProcessTask> {
+        return project.tasks.register(taskName, RpmPostProcessTask::class.java) {
+            rpmDirectory.set(project.layout.buildDirectory.dir("compose/binaries/$buildType/rpm"))
+            packageName.set(config.packageName)
+            appName.set(config.appName)
+            execPath.set(config.execPath)
+            iconPath.set(config.iconPath)
+            config.startupWMClass?.let { startupWMClass.set(it) }
+            categories.set(config.categories)
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/RpmPostProcessTask.kt
+++ b/buildSrc/src/main/kotlin/io/github/kdroidfilter/buildsrc/RpmPostProcessTask.kt
@@ -1,0 +1,242 @@
+package io.github.kdroidfilter.buildsrc
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.io.File
+
+/**
+ * Post-processes a .rpm package to inject a .desktop file.
+ * Required when using jpackage --app-image mode, which skips .desktop generation.
+ *
+ * Uses rpm2cpio/cpio to extract, adds the .desktop file, then rebuilds with rpmbuild.
+ */
+@DisableCachingByDefault(because = "Modifies .rpm in place")
+abstract class RpmPostProcessTask : DefaultTask() {
+
+    @get:InputDirectory
+    abstract val rpmDirectory: DirectoryProperty
+
+    @get:Input
+    abstract val packageName: Property<String>
+
+    @get:Input
+    abstract val appName: Property<String>
+
+    @get:Input
+    abstract val execPath: Property<String>
+
+    @get:Input
+    abstract val iconPath: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val startupWMClass: Property<String>
+
+    @get:Input
+    @get:Optional
+    abstract val categories: Property<String>
+
+    init {
+        group = "distribution"
+        description = "Post-process .rpm: inject .desktop file"
+        categories.convention("AudioVideo;Audio;Video;Network;")
+    }
+
+    @TaskAction
+    fun execute() {
+        if (!System.getProperty("os.name").lowercase().contains("linux")) {
+            logger.lifecycle("[rpmPostProcess] Skipped (non-Linux OS)")
+            return
+        }
+
+        val rpmDir = rpmDirectory.get().asFile
+        val rpmFile = rpmDir.listFiles()?.firstOrNull { it.extension == "rpm" }
+        if (rpmFile == null) {
+            logger.warn("[rpmPostProcess] No .rpm file found in ${rpmDir.absolutePath}")
+            return
+        }
+
+        logger.lifecycle("[rpmPostProcess] Processing ${rpmFile.name}")
+
+        val workDir = File(rpmFile.parentFile, "rpm-work")
+        try {
+            processRpmFile(rpmFile, workDir)
+        } finally {
+            workDir.deleteRecursively()
+        }
+    }
+
+    private fun processRpmFile(rpmFile: File, workDir: File) {
+        workDir.deleteRecursively()
+        workDir.mkdirs()
+
+        // Create a local rpmdb to avoid permission issues with the system rpmdb
+        val localRpmDb = File(workDir, "rpmdb")
+        localRpmDb.mkdirs()
+
+        // Extract RPM contents
+        val extractDir = File(workDir, "root")
+        extractDir.mkdirs()
+        exec("sh", "-c", "cd '${extractDir.absolutePath}' && rpm2cpio '${rpmFile.absolutePath}' | cpio -idmv")
+
+        // Create .desktop file
+        createDesktopFile(extractDir)
+
+        // Query RPM metadata (stderr separated to avoid rpmdb warnings polluting values)
+        val name = queryRpm(rpmFile, "%{NAME}")
+        val rpmVersion = queryRpm(rpmFile, "%{VERSION}")
+        val release = queryRpm(rpmFile, "%{RELEASE}")
+        val arch = queryRpm(rpmFile, "%{ARCH}")
+        val summary = queryRpm(rpmFile, "%{SUMMARY}").ifEmpty { appName.get() }
+        val license = queryRpm(rpmFile, "%{LICENSE}").ifEmpty { "Unknown" }
+        val description = queryRpm(rpmFile, "%{DESCRIPTION}").ifEmpty { appName.get() }
+
+        logger.lifecycle("[rpmPostProcess] RPM metadata: name=$name version=$rpmVersion release=$release arch=$arch")
+
+        // Query pre/post scripts to preserve them
+        val preIn = queryRpm(rpmFile, "%{PREIN}")
+        val postIn = queryRpm(rpmFile, "%{POSTIN}")
+        val preUn = queryRpm(rpmFile, "%{PREUN}")
+        val postUn = queryRpm(rpmFile, "%{POSTUN}")
+
+        // Build file list from extracted tree
+        val fileEntries = buildString {
+            extractDir.walkTopDown().sorted().forEach { file ->
+                val relPath = "/" + file.relativeTo(extractDir).path
+                if (relPath == "/") return@forEach
+                if (file.isDirectory) {
+                    appendLine("%dir \"$relPath\"")
+                } else {
+                    appendLine("\"$relPath\"")
+                }
+            }
+        }
+
+        // Generate spec file
+        val specContent = buildString {
+            appendLine("Name: $name")
+            appendLine("Version: $rpmVersion")
+            appendLine("Release: $release")
+            appendLine("Summary: $summary")
+            appendLine("License: $license")
+            appendLine("AutoReqProv: no")
+            appendLine()
+            appendLine("%description")
+            appendLine(description)
+            appendLine()
+            appendLine("%install")
+            appendLine("cp -a '${extractDir.absolutePath}'/* %{buildroot}/")
+            appendLine()
+            if (preIn.isNotEmpty()) {
+                appendLine("%pre")
+                appendLine(preIn)
+                appendLine()
+            }
+            if (postIn.isNotEmpty()) {
+                appendLine("%post")
+                appendLine(postIn)
+                appendLine()
+            }
+            if (preUn.isNotEmpty()) {
+                appendLine("%preun")
+                appendLine(preUn)
+                appendLine()
+            }
+            if (postUn.isNotEmpty()) {
+                appendLine("%postun")
+                appendLine(postUn)
+                appendLine()
+            }
+            appendLine("%files")
+            append(fileEntries)
+        }
+
+        val specFile = File(workDir, "rebuild.spec")
+        specFile.writeText(specContent)
+
+        // Set up rpmbuild directory structure
+        val rpmbuildDir = File(workDir, "rpmbuild")
+        listOf("BUILD", "RPMS", "SOURCES", "SPECS", "SRPMS", "BUILDROOT").forEach {
+            File(rpmbuildDir, it).mkdirs()
+        }
+
+        // Build new RPM with local rpmdb to avoid system rpmdb permission issues
+        exec(
+            "rpmbuild", "-bb",
+            "--define", "_topdir ${rpmbuildDir.absolutePath}",
+            "--define", "_dbpath ${localRpmDb.absolutePath}",
+            "--target", arch,
+            specFile.absolutePath
+        )
+
+        // Find the rebuilt RPM
+        val builtRpm = File(rpmbuildDir, "RPMS/$arch").listFiles()
+            ?.firstOrNull { it.extension == "rpm" }
+            ?: error("Failed to find rebuilt RPM in ${rpmbuildDir.absolutePath}/RPMS/$arch")
+
+        // Replace original with rebuilt RPM
+        val originalName = rpmFile.name
+        rpmFile.delete()
+        builtRpm.copyTo(rpmFile)
+
+        logger.lifecycle("[rpmPostProcess] Successfully rebuilt $originalName with .desktop file")
+    }
+
+    private fun createDesktopFile(dataDir: File) {
+        val appsDir = File(dataDir, "usr/share/applications")
+        appsDir.mkdirs()
+
+        val desktopFileName = "${packageName.get()}-${appName.get()}.desktop"
+        val desktopFile = File(appsDir, desktopFileName)
+
+        val content = buildString {
+            appendLine("[Desktop Entry]")
+            appendLine("Name=${appName.get()}")
+            appendLine("Comment=${appName.get()}")
+            appendLine("Exec=${execPath.get()} %U")
+            appendLine("Icon=${iconPath.get()}")
+            appendLine("Terminal=false")
+            appendLine("Type=Application")
+            appendLine("Categories=${categories.get()}")
+            if (startupWMClass.isPresent) {
+                appendLine("StartupWMClass=${startupWMClass.get()}")
+            }
+        }
+
+        desktopFile.writeText(content)
+        logger.lifecycle("[rpmPostProcess] Created ${desktopFile.name}")
+    }
+
+    /**
+     * Query RPM metadata. Stderr is discarded to avoid rpmdb warnings polluting the result.
+     */
+    private fun queryRpm(rpmFile: File, format: String): String {
+        val process = ProcessBuilder("rpm", "-qp", "--queryformat", format, rpmFile.absolutePath)
+            .redirectErrorStream(false)
+            .start()
+        // Discard stderr (rpmdb warnings)
+        process.errorStream.bufferedReader().readText()
+        val output = process.inputStream.bufferedReader().readText().trim()
+        process.waitFor()
+        return if (output == "(none)") "" else output
+    }
+
+    private fun exec(vararg args: String, workDir: File? = null) {
+        val process = ProcessBuilder(*args)
+            .apply { workDir?.let { directory(it) } }
+            .redirectErrorStream(true)
+            .start()
+
+        val output = process.inputStream.bufferedReader().readText()
+        val exitCode = process.waitFor()
+        if (exitCode != 0) {
+            error("Command failed with exit code $exitCode: ${args.joinToString(" ")}\n$output")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Integrate JDK Project Leyden AOT cache generation into the build pipeline for faster app startup
- Dev mode support via `-Paot=train|on|auto|off` flag on `./gradlew :composeApp:run`
- Distributable AOT tasks (`generateDistributableAotCache` / `generateReleaseDistributableAotCache`) that train the app ~20s, record class loading profile, and create a bundled AOT cache
- Release packaging (DMG/MSI/Deb/Rpm/Pkg) automatically includes the AOT cache
- Fix: AOT training provisions a temporary java launcher inside the distributable's jlink'd runtime so `lib/modules` checksum matches at runtime (prevents `Unable to map shared spaces` error)
- Add `aotClean` task to delete cached data and force re-training

## Benchmark

### macOS (MacBook Air M4, AeroDl v0.7.0, JDK 25-ea)

#### Startup time (time to first window, 5 runs)

| Run | Without AOT | With AOT |
|-----|-------------|----------|
| 1 | 3.278s | 1.496s |
| 2 | 2.137s | 1.629s |
| 3 | 3.056s | 1.955s |
| 4 | 2.846s | 2.630s |
| 5 | 3.380s | 2.998s |
| **Average** | **2.939s** | **2.142s** |
| **Min** | **2.137s** | **1.496s** |

**~27% faster startup on average**, with best-case improvement of ~55%.

#### Memory usage (after startup, idle)

Measured by launching the app, waiting 8s for it to settle, then collecting metrics via `ps`, `jcmd GC.heap_info`, and `vmmap`.

| Metric | Without AOT | With AOT | Delta |
|--------|-------------|----------|-------|
| RSS | 293 MB | 318 MB | +25 MB |
| Physical footprint | 328 MB | 388 MB | +60 MB |
| JVM Heap committed | 142 MB | 258 MB | +116 MB |
| JVM Heap used | 43 MB | 81 MB | +38 MB |
| AOT cache mmap (COW) | 0 | ~60 MB | +60 MB |

The AOT cache adds ~60 MB physical memory overhead (memory-mapped copy-on-write). The higher heap is expected as AOT pre-loads more classes at startup.

### Windows (Intel 14600, DDR5 6000mhz, SSD NVME 4.0 AeroDl v0.7.0, JDK 25-ea)

#### Startup time (time to first window, 5 runs)

| Run | Without AOT | With AOT |
|-----|-------------|----------|
| 1 | 1.774s | 1.601s |
| 2 | 1.776s | 1.575s |
| 3 | 1.838s | 1.512s |
| 4 | 1.855s | 1.541s |
| 5 | 1.759s | 1.509s |
| **Average** | **1.800s** | **1.548s** |
| **Min** | **1.759s** | **1.509s** |

**~14% faster startup on average**, with best-case improvement of ~14%.

<details>
<summary>Startup benchmark script (macOS)</summary>

```bash
#!/bin/bash
# Benchmark AeroDl startup time: measures until first window is visible
APP="/Applications/AeroDl.app/Contents/MacOS/AeroDl"
RUNS=5

echo "=== AeroDl Startup Benchmark (time to first window) ==="
echo "Runs: $RUNS"
echo ""

all_times=""

for i in $(seq 1 $RUNS); do
    pkill -f "AeroDl" 2>/dev/null
    sleep 3

    start=$(python3 -c "import time; print(time.time())")
    $APP &>/dev/null &

    # Wait until a window belonging to the app exists
    while true; do
        count=$(osascript -e 'tell application "System Events" to count (windows of process "AeroDl")' 2>/dev/null)
        if [ "$count" != "" ] && [ "$count" -gt 0 ] 2>/dev/null; then
            break
        fi
        sleep 0.05
    done

    end=$(python3 -c "import time; print(time.time())")
    elapsed=$(python3 -c "print(f'{$end - $start:.3f}')")
    all_times="$all_times $elapsed"
    echo "  Run $i: ${elapsed}s"

    pkill -f "AeroDl" 2>/dev/null
    sleep 1
done

python3 -c "
times = [float(x) for x in '$all_times'.split()]
avg = sum(times) / len(times)
mn = min(times)
mx = max(times)
print()
print(f'Average: {avg:.3f}s  |  Min: {mn:.3f}s  |  Max: {mx:.3f}s')
"
```

</details>

<details>
<summary>Startup benchmark script (Windows)</summary>

```powershell
$APP = "C:\Users\Elie\AppData\Local\AeroDl\AeroDl.exe"
$RUNS = 5

Add-Type @"
using System;
using System.Collections.Generic;
using System.Runtime.InteropServices;

public class WindowHelper {
    [DllImport("user32.dll")]
    private static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);

    [DllImport("user32.dll")]
    private static extern bool IsWindowVisible(IntPtr hWnd);

    private delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);

    private static List<IntPtr> _windows;

    private static bool EnumCallback(IntPtr hWnd, IntPtr lParam) {
        if (IsWindowVisible(hWnd)) {
            _windows.Add(hWnd);
        }
        return true;
    }

    public static IntPtr[] GetVisibleWindows() {
        _windows = new List<IntPtr>();
        EnumWindows(EnumCallback, IntPtr.Zero);
        return _windows.ToArray();
    }
}
"@

Write-Host "=== AeroDl Startup Benchmark (time to first window) ==="
Write-Host "Runs: $RUNS"

$allTimes = @()

for ($i = 1; $i -le $RUNS; $i++) {
    Stop-Process -Name "AeroDl" -Force -ErrorAction SilentlyContinue
    Start-Sleep -Seconds 3

    $before = [WindowHelper]::GetVisibleWindows()
    $stopwatch = [System.Diagnostics.Stopwatch]::StartNew()
    $proc = Start-Process -FilePath $APP -PassThru

    while ($true) {
        $after = [WindowHelper]::GetVisibleWindows()
        $newWindows = $after | Where-Object { $before -notcontains $_ }
        if ($newWindows.Count -gt 0) { break }
        Start-Sleep -Milliseconds 50
    }

    $stopwatch.Stop()
    $elapsed = [math]::Round($stopwatch.Elapsed.TotalSeconds, 3)
    $allTimes += $elapsed
    Write-Host "  Run ${i}: ${elapsed}s"

    Stop-Process -Name "AeroDl" -Force -ErrorAction SilentlyContinue
    Start-Sleep -Seconds 1
}

$avg = [math]::Round(($allTimes | Measure-Object -Average).Average, 3)
$min = [math]::Round(($allTimes | Measure-Object -Minimum).Minimum, 3)
$max = [math]::Round(($allTimes | Measure-Object -Maximum).Maximum, 3)

Write-Host "Average: ${avg}s  |  Min: ${min}s  |  Max: ${max}s"
```

</details>

<details>
<summary>Memory benchmark commands (macOS)</summary>

```bash
# Launch the app, wait 8s for it to settle
/Applications/AeroDl.app/Contents/MacOS/AeroDl &>/dev/null &
sleep 8
PID=$(jcmd | grep "io.github.kdroidfilter.ytdlpgui.MainKt" | awk '{print $1}')

# RSS (Resident Set Size) via ps
ps -p $PID -o pid,rss,vsz

# JVM heap info via jcmd
jcmd $PID GC.heap_info

# macOS physical footprint + AOT cache memory mapping via vmmap
vmmap $PID | grep "Physical footprint"
vmmap $PID | grep "aerodl.aot"
```

</details>

## Test plan
- [x] Run `./gradlew :composeApp:generateDistributableAotCache` and verify AOT cache is created
- [x] Launch the distributable and verify no `[error][aot]` in stderr
- [x] Verify via `jcmd <pid> VM.flags` that `-XX:AOTCache=...` and `-XX:+AOTReplayTraining` are active
- [x] Build DMG, install, and verify AOT cache loads without errors
- [x] Build MSI, install, and verify AOT cache loads without errors
- [x] Benchmark startup time with and without AOT cache (macOS + Windows)
- [x] Benchmark memory usage with and without AOT cache