### PR TITLE
fix(ci): align deploy workflow with test-aot to fix Windows memory bug

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -126,8 +126,6 @@ jobs:
       # Gradle Setup
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v3
-        with:
-          gradle-version: '8.14'
 
       # Builds (AOT cache is automatically generated via task dependencies)
       - name: Build Linux .deb
@@ -144,8 +142,10 @@ jobs:
 
       - name: Build Windows .msi
         if: startsWith(matrix.os, 'windows')
-        shell: pwsh
-        run: .\gradlew.bat :composeApp:packageReleaseMsi
+        shell: bash
+        run: |
+          chmod +x ./gradlew
+          ./gradlew :composeApp:packageReleaseMsi
 
       - name: Build macOS .pkg + .dmg + .zip
         if: startsWith(matrix.os, 'macos')


### PR DESCRIPTION
## Summary
- **Remove hardcoded `gradle-version: '8.14'`** from deploy.yaml so it uses the Gradle wrapper (9.2.1), matching the test-aot workflow which works correctly
- **Switch Windows build step** from `pwsh` + `gradlew.bat` to `bash` + `./gradlew` for consistency with test-aot

## Context
Installers generated by `test-aot.yaml` (PR #79) work fine, but releases built by `deploy.yaml` (v1.8.0, v1.8.1) have a memory bug at startup on Windows. The root cause is that deploy.yaml was forcing Gradle 8.14 instead of using the project's wrapper (9.2.1), leading to different packaging behavior and JVM options in the generated installer.

## Test plan
- [ ] Tag a new release and verify the Windows .msi installer starts without memory errors
- [ ] Verify AOT cache is still generated correctly on all platforms
