### PR TITLE
fix(aot): skip network init during AOT training to fix memory bloat

### DIFF
--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/init/InitViewModel.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/features/init/InitViewModel.kt
@@ -52,29 +52,38 @@ class InitViewModel(
     private var manifest: ReleaseManifest? = null
 
     init {
-        viewModelScope.launch {
-            // Fetch the manifest FIRST, regardless of onboarding status
-            // This is needed for downloading yt-dlp/ffmpeg during onboarding
-            manifest = releaseManifestRepository.getManifest()
+        if (System.getProperty("aot.training.autoExit") != null) {
+            // During AOT cache recording, skip all network/initialization to keep
+            // the cache lean. Loading Ktor/SSL/serialization classes during training
+            // bloats the cache and wastes ~800 MB of memory at every app startup.
+            viewModelScope.launch {
+                update { copy(initCompleted = true, navigationState = InitNavigationState.NavigateToHome) }
+            }
+        } else {
+            viewModelScope.launch {
+                // Fetch the manifest FIRST, regardless of onboarding status
+                // This is needed for downloading yt-dlp/ffmpeg during onboarding
+                manifest = releaseManifestRepository.getManifest()
 
-            // Check if onboarding is completed
-            val onboardingCompleted = settingsRepository.isOnboardingCompleted()
+                // Check if onboarding is completed
+                val onboardingCompleted = settingsRepository.isOnboardingCompleted()
 
-            if (!onboardingCompleted) {
-                // Not configured → go to onboarding
-                update { copy(navigationState = InitNavigationState.NavigateToOnboarding) }
-                return@launch
+                if (!onboardingCompleted) {
+                    // Not configured → go to onboarding
+                    update { copy(navigationState = InitNavigationState.NavigateToOnboarding) }
+                    return@launch
+                }
+
+                // Check for app updates using the manifest
+                manifest?.let { checkForUpdates(it) }
+
+                // Already configured → initialize yt-dlp and ffmpeg
+                startInitialization(navigateToHomeWhenDone = true)
             }
 
-            // Check for app updates using the manifest
-            manifest?.let { checkForUpdates(it) }
-
-            // Already configured → initialize yt-dlp and ffmpeg
-            startInitialization(navigateToHomeWhenDone = true)
+            // Schedule periodic update checks every 12 hours (no overlap if previous run is still active)
+            startPeriodicUpdateChecks()
         }
-
-        // Schedule periodic update checks every 12 hours (no overlap if previous run is still active)
-        startPeriodicUpdateChecks()
     }
 
     @OptIn(kotlin.time.ExperimentalTime::class)


### PR DESCRIPTION
## Summary

- Skip all network/initialization in `InitViewModel` during AOT cache recording to prevent loading Ktor/SSL/JSON classes into the cache
- Navigate directly to home screen during training for UI class coverage
- Fixes the ~1.3 GB memory regression on Windows introduced in v1.8.0

## Root Cause

PR #81 moved `releaseManifestRepository.getManifest()` to run **before** the onboarding check. On CI (fresh install = onboarding not completed):

| Version | AOT training behavior |
|---------|----------------------|
| **v1.7.0** | `isOnboardingCompleted()` → false → return. **No HTTP request.** |
| **v1.8.0+** | `getManifest()` → Ktor HTTPS request → loads SSL/JSON classes → then checks onboarding. |

These extra classes get permanently baked into the AOT cache and eagerly preloaded at every startup, causing ~800 MB of wasted memory.

## Test plan

- [ ] Merge and create tag v1.8.3
- [ ] Verify AOT cache is smaller (~59 MB like v1.7.0 instead of ~70 MB)
- [ ] Verify Windows MSI working set is ~400-500 MB instead of ~1.3 GB
- [ ] Verify normal app functionality (init/download) still works