### PR TITLE
refactor: replace static manifest with direct GitHub API calls

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -78,6 +78,7 @@ kotlin {
             implementation(libs.platformtools.core)
             implementation(libs.platformtools.darkmodedetector)
             implementation(libs.platformtools.clipboardmanager)
+            implementation(libs.platformtools.releasefetcher)
             implementation(libs.autolaunch)
             implementation(libs.filekit.core)
             implementation(libs.filekit.dialogs)

--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/data/ReleaseManifestRepository.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/data/ReleaseManifestRepository.kt
@@ -1,48 +1,79 @@
 package io.github.kdroidfilter.ytdlpgui.data
 
 import io.github.kdroidfilter.logging.LoggerConfig
-import io.github.kdroidfilter.network.HttpsConnectionFactory
+import io.github.kdroidfilter.network.KtorConfig
+import io.github.kdroidfilter.platformtools.releasefetcher.github.GitHubReleaseFetcher
+import io.github.kdroidfilter.platformtools.releasefetcher.github.model.Release
+import io.github.kdroidfilter.ytdlp.model.AssetInfo
+import io.github.kdroidfilter.ytdlp.model.ReleaseEntries
+import io.github.kdroidfilter.ytdlp.model.ReleaseInfo
 import io.github.kdroidfilter.ytdlp.model.ReleaseManifest
-import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.protobuf.ProtoBuf
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import java.time.Instant
 
 /**
- * Fetches the static release manifest in protobuf format.
- * No HTTP call at startup to avoid AOT cache memory bloat.
- * Network fetch happens only during onboarding or periodic checks.
+ * Fetches release information directly from the GitHub API via GitHubReleaseFetcher.
+ * Network fetch happens only during onboarding or periodic checks (not during AOT training).
  */
-@OptIn(ExperimentalSerializationApi::class)
 class ReleaseManifestRepository {
 
     @Volatile
     private var cached: ReleaseManifest? = null
 
-    /**
-     * Returns the in-memory cached manifest, or null if not yet fetched.
-     */
     fun getCachedManifest(): ReleaseManifest? = cached
 
     /**
-     * Fetches manifest from network as protobuf and caches in memory.
+     * Fetches latest releases from the GitHub API in parallel and builds the manifest.
      */
     suspend fun fetchManifest(): ReleaseManifest? {
+        val httpClient = KtorConfig.createHttpClient()
         return runCatching {
-            val conn = HttpsConnectionFactory.openConnection(MANIFEST_URL)
-            val bytes = try {
-                conn.inputStream.readBytes()
-            } finally {
-                conn.disconnect()
+            coroutineScope {
+                val ytDlp = async { fetchRelease("yt-dlp", "yt-dlp", httpClient) }
+                val ffmpeg = async { fetchRelease("yt-dlp", "FFmpeg-Builds", httpClient) }
+                val ffmpegMacos = async { fetchRelease("kdroidFilter", "FFmpeg-Builds", httpClient) }
+                val deno = async { fetchRelease("denoland", "deno", httpClient) }
+                val aerodl = async { fetchRelease("kdroidFilter", "AeroDL", httpClient) }
+                val python = async { fetchRelease("indygreg", "python-build-standalone", httpClient) }
+
+                ReleaseManifest(
+                    generatedAt = Instant.now().toString(),
+                    schemaVersion = 1,
+                    releases = ReleaseEntries(
+                        ytDlp = ytDlp.await(),
+                        ytDlpScript = ytDlp.await(),
+                        python = python.await(),
+                        ffmpeg = ffmpeg.await(),
+                        ffmpegMacos = ffmpegMacos.await(),
+                        deno = deno.await(),
+                        aerodl = aerodl.await()
+                    )
+                )
             }
-            ProtoBuf.decodeFromByteArray(ReleaseManifest.serializer(), bytes)
         }.onFailure { error ->
             if (LoggerConfig.enabled) {
                 System.err.println("[ReleaseManifestRepository] Failed to fetch manifest: ${error.message}")
                 error.printStackTrace()
             }
+        }.also {
+            httpClient.close()
         }.getOrNull()?.also { cached = it }
     }
 
-    companion object {
-        const val MANIFEST_URL = "https://kdroidfilter.github.io/AeroDL/api/releases.pb"
+    private suspend fun fetchRelease(
+        owner: String,
+        repo: String,
+        httpClient: io.ktor.client.HttpClient
+    ): ReleaseInfo {
+        val release = GitHubReleaseFetcher(owner, repo, httpClient).getLatestRelease()
+            ?: error("Failed to fetch $owner/$repo release")
+        return release.toReleaseInfo()
     }
 }
+
+private fun Release.toReleaseInfo() = ReleaseInfo(
+    tagName = tag_name,
+    body = body,
+    assets = assets.map { AssetInfo(it.name, it.browser_download_url) }
+)


### PR DESCRIPTION
## Summary

- Replace the static protobuf manifest fetch (`https://kdroidfilter.github.io/AeroDL/api/releases.pb`) with direct GitHub API calls via `GitHubReleaseFetcher`
- Re-add `platformtools.releasefetcher` dependency to `composeApp`
- All 6 repos (yt-dlp, ffmpeg, ffmpeg-macos, deno, aerodl, python) are fetched in parallel via `coroutineScope`/`async`
- `ReleaseManifest` data model is unchanged — all consumers work as before
- AOT training guard (from PR #91) prevents these calls during AOT cache generation

## Test plan

- [ ] App startup fetches releases and shows update notification if available
- [ ] FFmpeg/Deno are resolved correctly on first install and after restart
- [ ] AOT training still skips network calls