### PR TITLE
fix: use OPENGL renderer on Windows 10

### DIFF
--- a/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/main.kt
+++ b/composeApp/src/jvmMain/kotlin/io/github/kdroidfilter/ytdlpgui/main.kt
@@ -72,7 +72,13 @@ fun main() {
     // Configure Skiko render API based on platform (respect pre-set -D flag)
     if (System.getProperty("skiko.renderApi") == null) {
         when (getOperatingSystem()) {
-            OperatingSystem.WINDOWS -> System.setProperty("skiko.renderApi", "DIRECT3D")
+            OperatingSystem.WINDOWS -> {
+                if (isWindows10()) {
+                    System.setProperty("skiko.renderApi", "OPENGL")
+                } else {
+                    System.setProperty("skiko.renderApi", "DIRECT3D")
+                }
+            }
             OperatingSystem.LINUX -> if (isNvidiaGpuPresent()) {
                 System.setProperty("skiko.renderApi", "SOFTWARE")
             }
@@ -244,6 +250,11 @@ fun clearAppData() {
 private fun clearSettings(settings: Settings) {
     settings.clear()
     infoln { "Settings cleared" }
+}
+
+private fun isWindows10(): Boolean {
+    val osName = System.getProperty("os.name", "").lowercase()
+    return osName.contains("windows 10")
 }
 
 private fun isNvidiaGpuPresent(): Boolean {


### PR DESCRIPTION
## Summary
- set Skiko render API to OPENGL on Windows 10 when skiko.renderApi is not already defined
- keep DIRECT3D as default for other Windows versions
- add a small helper to detect Windows 10 from os.name

## Validation
- ./gradlew :composeApp:compileKotlinJvm