### PR TITLE
chore(deps): bump Nucleus, macosui, Yaru, and composenativetray

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,14 +21,14 @@ cardiologist = "0.8.0"
 
 # UI Libraries
 fluent = "1.1.2"
-yaru = "1.0.3"
-macosui = "1.0.4"
+yaru = "1.0.4"
+macosui = "1.1.0"
 composemediaplayer = "0.11.4"
-composenativetray = "2.1.2"
+composenativetray = "2.1.3"
 
 # Network & Tools
 ktor = "3.5.2"
-nucleus = "2.5.4"
+nucleus = "2.5.5"
 metro = "1.4.2"
 sqliteJdbc = "3.53.4.0"
 


### PR DESCRIPTION
## Summary

- Bump Nucleus from 2.5.4 to 2.5.5
- Bump macosui from 1.0.4 to 1.1.0
- Bump Yaru from 1.0.3 to 1.0.4
- Bump composenativetray from 2.1.2 to 2.1.3

## Test plan

- [ ] `./gradlew :composeApp:compileKotlinJvm` succeeds with the new versions
- [ ] Launch the app and smoke-check home, download, and settings on the native UI backend

## Type

chore